### PR TITLE
Fix broken admin tests on master merge

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: '0'
       - name: Bump version and push tag
         id: bump-version
-        uses: anothrNick/github-tag-action@1.17.2
+        uses: anothrNick/github-tag-action@1.34.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
@@ -121,11 +121,10 @@ jobs:
     name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Unit Tests
-        uses: cedrickring/golang-action@1.5.2
+        uses: cedrickring/golang-action@1.7.0
         env:
           GO111MODULE: "on"
         with:
@@ -137,7 +136,7 @@ jobs:
           flags: unittests
           fail_ci_if_error: true
       - name: Lint
-        uses: cedrickring/golang-action@1.5.2
+        uses: cedrickring/golang-action@1.7.0
         env:
           GO111MODULE: "on"
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,11 +83,10 @@ jobs:
     name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Unit Tests
-        uses: cedrickring/golang-action@1.5.2
+        uses: cedrickring/golang-action@1.7.0
         env:
           GO111MODULE: "on"
         with:
@@ -99,7 +98,7 @@ jobs:
           flags: unittests
           fail_ci_if_error: true
       - name: Lint
-        uses: cedrickring/golang-action@1.5.2
+        uses: cedrickring/golang-action@1.7.0
         env:
           GO111MODULE: "on"
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,10 +83,11 @@ jobs:
     name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Unit Tests
-        uses: cedrickring/golang-action@1.7.0
+        uses: cedrickring/golang-action@1.5.2
         env:
           GO111MODULE: "on"
         with:
@@ -98,7 +99,7 @@ jobs:
           flags: unittests
           fail_ci_if_error: true
       - name: Lint
-        uses: cedrickring/golang-action@1.7.0
+        uses: cedrickring/golang-action@1.5.2
         env:
           GO111MODULE: "on"
         with:


### PR DESCRIPTION
# TL;DR
Flyteadmin tests & goreleaser broken on merges to master. This PR updates the goreleaser step to use the latest version of [GH tag actions](https://github.com/anothrNick/github-tag-action) and [go command ](https://github.com/cedrickring/golang-action)to run tests.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/844

## Follow-up issue
_NA_