### PR TITLE
Added script and compiler option to run admin in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ k8s_integration_execute:
 compile:
 	go build -o flyteadmin -ldflags=$(LD_FLAGS) ./cmd/ && mv ./flyteadmin ${GOPATH}/bin
 
+.PHONY: compile_debug
+compile_debug:
+	go build -gcflags='all=-N -l' -o flyteadmin ./cmd/ && mv ./flyteadmin ${GOPATH}/bin
+
+
 .PHONY: linux_compile
 linux_compile:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0  go build -o /artifacts/flyteadmin -ldflags=$(LD_FLAGS) ./cmd/

--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,2 @@
+dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec ${GOPATH}/bin/flyteadmin serve -- --config  flyteadmin_config.yaml --server.kube-config ~/.kube/config
+


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Running admin in debug mode requires the compiler output to have debug bits.
Added a new Makefile target compile_debug which does this and the script debug.sh uses dlv to run the admin in debug mode for the serve option

Similarly the script can be modified to run for other commandline options exposed by flyteadmin

Pre-reequisite:
Install dlv  : https://github.com/go-delve/delve/blob/master/Documentation/installation/README.md
Setup IDE Debug configuration. The port for DLV should match
eg  
<img width="1048" alt="Screenshot 2021-04-15 at 3 30 10 PM" src="https://user-images.githubusercontent.com/77798312/114851955-f5bda580-9dff-11eb-9f17-cd9ad4fe79cf.png">


## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
