### PR TITLE
Logging the request URI from IDP

### DIFF
--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -133,7 +133,7 @@ func GetLoginHandler(ctx context.Context, authCtx interfaces.AuthenticationConte
 // the user authentication flow.
 func GetCallbackHandler(ctx context.Context, authCtx interfaces.AuthenticationContext) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		logger.Debugf(ctx, "Running callback handler...")
+		logger.Debugf(ctx, "Running callback handler... for RequestURI %v", request.RequestURI)
 		authorizationCode := request.FormValue(AuthorizationResponseCodeType)
 
 		err := VerifyCsrfCookie(ctx, request)


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Trivial change to log the Request URI on callback from the IDP which gives crucial information which was missing in the logs.
eg 

```
{"json":{"src":"handlers.go:136"},"level":"debug","msg":"Running callback handler... for RequestURI /callback?state=f81746199a0ccae0e6de3b99745b70ac75c120b2d555644e76b08541fd3ecb6f\u0026error=access_denied\u0026error_description=User+is+not+assigned+to+the+client+application.","ts":"2021-05-03T19:09:01+05:30"}
{"json":{"src":"handlers.go:148"},"level":"error","msg":"Error when exchanging code oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"error\":\"invalid_grant\",\"error_description\":\"The authorization code is invalid or has expired.\"}","ts":"2021-05-03T19:09:02+05:30"}
```
Without the first line where there is an error from IDP it would be difficult to know why the authorization code is invalid.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 Trivial change
## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_

