### PR TITLE
Print stacktrace in interceptPanic

### DIFF
--- a/pkg/rpc/adminservice/base.go
+++ b/pkg/rpc/adminservice/base.go
@@ -51,7 +51,7 @@ func (m *AdminService) interceptPanic(ctx context.Context, request proto.Message
 	}
 
 	m.Metrics.PanicCounter.Inc()
-	logger.Fatalf(ctx, "panic-ed for request: [%+v] with err: %v", request, err)
+	logger.Fatalf(ctx, "panic-ed for request: [%+v] with err: %v with Stack: %v", request, err, string(debug.Stack()))
 }
 
 const defaultRetries = 3

--- a/pkg/rpc/adminservice/base_test.go
+++ b/pkg/rpc/adminservice/base_test.go
@@ -1,0 +1,40 @@
+package adminservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flyteorg/flytestdlib/logger"
+
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_interceptPanic(t *testing.T) {
+	m := AdminService{
+		Metrics: InitMetrics(promutils.NewTestScope()),
+	}
+
+	ctx := context.Background()
+
+	// Mute logs to avoid .Fatal() (called in interceptPanic) causing the process to close
+	assert.NoError(t, logger.SetConfig(&logger.Config{Mute: true}))
+
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+				assert.Fail(t, "Unexpected error", err)
+			}
+		}()
+
+		a := func() {
+			defer m.interceptPanic(ctx, proto.Message(nil))
+
+			var x *int
+			*x = 10
+		}
+
+		a()
+	}()
+}


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Print stacktrace in interceptPanic to help diagnose exceptions.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1039