### PR TITLE
wip : Fix workflow list request to return closure data aswell

### DIFF
--- a/pkg/manager/impl/workflow_manager.go
+++ b/pkg/manager/impl/workflow_manager.go
@@ -262,20 +262,16 @@ func (w *WorkflowManager) ListWorkflows(
 		InlineFilters: filters,
 		SortParameter: sortParameter,
 	}
-	output, err := w.db.WorkflowRepo().List(ctx, listWorkflowsInput)
-	if err != nil {
-		logger.Debugf(ctx, "Failed to list workflows with [%+v] with err %v", request.Id, err)
-		return nil, err
-	}
-	workflowList, err := transformers.FromWorkflowModels(output.Workflows)
+
+	workflowList, err := util.ListWorkflows(ctx, w.db, w.storageClient, listWorkflowsInput)
 	if err != nil {
 		logger.Errorf(ctx,
-			"Failed to transform workflow models [%+v] with err: %v", output.Workflows, err)
+			"Failed to transform workflow models [%+v] with err: %v", workflowList, err)
 		return nil, err
 	}
 	var token string
-	if len(output.Workflows) == int(request.Limit) {
-		token = strconv.Itoa(offset + len(output.Workflows))
+	if len(workflowList) == int(request.Limit) {
+		token = strconv.Itoa(offset + len(workflowList))
 	}
 	return &admin.WorkflowList{
 		Workflows: workflowList,

--- a/pkg/manager/impl/workflow_manager_test.go
+++ b/pkg/manager/impl/workflow_manager_test.go
@@ -416,7 +416,7 @@ func TestListWorkflows(t *testing.T) {
 	mockStorageClient.ComposedProtobufStore.(*commonMocks.TestDataStore).ReadProtobufCb =
 		func(ctx context.Context, reference storage.DataReference, msg proto.Message) error {
 			assert.Equal(t, remoteClosureIdentifier, reference.String())
-			assert.True(t, proto.Equal(testutils.GetWorkflowClosure(), msg))
+			assert.True(t, proto.Equal(&admin.WorkflowClosure{}, msg))
 			return nil
 		}
 	workflowManager := NewWorkflowManager(


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Return the closure in the workflow list response aswell.
This might have been omitted for a purpose may be due to size of the closure data.
If not this then can we have the client get the latest version using one call and then call get workflow with it.

But i do see that we return the entire objects in case of launch plan list request so fixing this in the admin would be ideal.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

Unit tests  pending

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1053

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
