### PR TITLE
Restore reading execution request spec role

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -611,12 +611,12 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 }
 
 func resolvePermissions(request *admin.ExecutionCreateRequest, launchPlan *admin.LaunchPlan) *admin.AuthRole {
-	// Set role permissions based on launch plan Auth values.
-	// The branched-ness of this check is due to the presence numerous deprecated fields
 	if request.Spec.AuthRole != nil {
 		return request.Spec.AuthRole
 	}
 
+	// Set role permissions based on launch plan Auth values.
+	// The branched-ness of this check is due to the presence numerous deprecated fields
 	if launchPlan.Spec.GetAuthRole() != nil {
 		return launchPlan.Spec.GetAuthRole()
 	} else if launchPlan.GetSpec().GetAuth() != nil {

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -610,6 +610,28 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 
 }
 
+func resolvePermissions(request *admin.ExecutionCreateRequest, launchPlan *admin.LaunchPlan) *admin.AuthRole {
+	// Set role permissions based on launch plan Auth values.
+	// The branched-ness of this check is due to the presence numerous deprecated fields
+	if request.Spec.AuthRole != nil {
+		return request.Spec.AuthRole
+	}
+
+	if launchPlan.Spec.GetAuthRole() != nil {
+		return launchPlan.Spec.GetAuthRole()
+	} else if launchPlan.GetSpec().GetAuth() != nil {
+		return &admin.AuthRole{
+			AssumableIamRole:         launchPlan.GetSpec().GetAuth().AssumableIamRole,
+			KubernetesServiceAccount: launchPlan.GetSpec().GetAuth().KubernetesServiceAccount,
+		}
+	} else if len(launchPlan.GetSpec().GetRole()) > 0 {
+		return &admin.AuthRole{
+			AssumableIamRole: launchPlan.GetSpec().GetRole(),
+		}
+	}
+	return &admin.AuthRole{}
+}
+
 func (m *ExecutionManager) launchExecutionAndPrepareModel(
 	ctx context.Context, request admin.ExecutionCreateRequest, requestedAt time.Time) (
 	context.Context, *models.Execution, error) {
@@ -713,6 +735,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		AcceptedAt:      requestedAt,
 		QueueingBudget:  qualityOfService.QueuingBudget,
 		ExecutionConfig: executionConfig,
+		Auth:            resolvePermissions(&request, launchPlan),
 	}
 	err = m.addLabelsAndAnnotations(request.Spec, &executeWorkflowInputs)
 	if err != nil {

--- a/pkg/workflowengine/impl/propeller_executor_test.go
+++ b/pkg/workflowengine/impl/propeller_executor_test.go
@@ -432,38 +432,10 @@ func TestAddPermissions(t *testing.T) {
 	cluster := getFakeExecutionCluster()
 	propeller := getFlytePropellerForTest(cluster, &FlyteWorkflowBuilderTest{})
 	flyteWf := v1alpha1.FlyteWorkflow{}
-	propeller.addPermissions(admin.LaunchPlan{
-		Spec: &admin.LaunchPlanSpec{
-			Auth: &admin.Auth{
-				AssumableIamRole: "rollie-pollie",
-			},
-			Role: "ignore-me",
-		},
+	propeller.addPermissions(&admin.AuthRole{
+		AssumableIamRole:         "rollie-pollie",
+		KubernetesServiceAccount: "service-account",
 	}, &flyteWf)
-	assert.EqualValues(t, flyteWf.Annotations, map[string]string{
-		roleNameKey: "rollie-pollie",
-	})
-
-	flyteWf = v1alpha1.FlyteWorkflow{}
-	propeller.addPermissions(admin.LaunchPlan{
-		Spec: &admin.LaunchPlanSpec{
-			Role: "rollie-pollie",
-		},
-	}, &flyteWf)
-	assert.EqualValues(t, flyteWf.Annotations, map[string]string{
-		roleNameKey: "rollie-pollie",
-	})
-
-	flyteWf = v1alpha1.FlyteWorkflow{}
-	propeller.addPermissions(admin.LaunchPlan{
-		Spec: &admin.LaunchPlanSpec{
-			Auth: &admin.Auth{
-				KubernetesServiceAccount: "service-account",
-				AssumableIamRole:         "rollie-pollie",
-			},
-		},
-	}, &flyteWf)
-	assert.Equal(t, "service-account", flyteWf.ServiceAccountName)
 	assert.EqualValues(t, flyteWf.Annotations, map[string]string{
 		roleNameKey: "rollie-pollie",
 	})

--- a/pkg/workflowengine/impl/propeller_executor_test.go
+++ b/pkg/workflowengine/impl/propeller_executor_test.go
@@ -41,6 +41,9 @@ var clusterName = "C1"
 
 var acceptedAt = time.Now()
 
+const testRole = "role"
+const testK8sServiceAccount = "sa"
+
 func getFlytePropellerForTest(execCluster interfaces2.ClusterInterface, builder *FlyteWorkflowBuilderTest) *FlytePropeller {
 	return &FlytePropeller{
 		executionCluster: execCluster,
@@ -143,8 +146,8 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 				"customlabel": "labelval",
 			}, workflow.Labels)
 			expectedAnnotations := map[string]string{
-				"iam.amazonaws.com/role": "role-1",
-				"customannotation":       "annotationval",
+				roleNameKey:        testRole,
+				"customannotation": "annotationval",
 			}
 			assert.EqualValues(t, expectedAnnotations, workflow.Annotations)
 
@@ -155,6 +158,7 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 				},
 			}, workflow.ExecutionConfig.TaskPluginImpls)
 			assert.Empty(t, opts)
+			assert.Equal(t, workflow.ServiceAccountName, testK8sServiceAccount)
 			return nil, nil
 		},
 	}
@@ -179,7 +183,6 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 					Domain:  "lp-d",
 				},
 				Spec: &admin.LaunchPlanSpec{
-					Role: "role-1",
 					WorkflowId: &core.Identifier{
 						Name: "wf",
 					},
@@ -199,6 +202,10 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 					MissingPluginBehavior: admin.PluginOverride_USE_DEFAULT,
 				},
 			},
+			Auth: &admin.AuthRole{
+				AssumableIamRole:         testRole,
+				KubernetesServiceAccount: testK8sServiceAccount,
+			},
 		})
 	assert.Nil(t, err)
 	assert.NotNil(t, execInfo)
@@ -210,7 +217,7 @@ func TestExecuteWorkflowCallFailed(t *testing.T) {
 	fakeFlyteWorkflow := FakeFlyteWorkflow{
 		createCallback: func(workflow *v1alpha1.FlyteWorkflow, opts v1.CreateOptions) (*v1alpha1.FlyteWorkflow, error) {
 			expectedAnnotations := map[string]string{
-				"iam.amazonaws.com/role": "role-1",
+				roleNameKey: testRole,
 			}
 			assert.EqualValues(t, expectedAnnotations, workflow.Annotations)
 			assert.Empty(t, opts)
@@ -242,13 +249,15 @@ func TestExecuteWorkflowCallFailed(t *testing.T) {
 					Domain:  "d",
 				},
 				Spec: &admin.LaunchPlanSpec{
-					Role: "role-1",
 					WorkflowId: &core.Identifier{
 						Name: "wf",
 					},
 				},
 			},
 			AcceptedAt: acceptedAt,
+			Auth: &admin.AuthRole{
+				AssumableIamRole: testRole,
+			},
 		})
 
 	assert.NotNil(t, err)
@@ -295,13 +304,15 @@ func TestExecuteWorkflowAlreadyExistsNoError(t *testing.T) {
 					Domain:  "d",
 				},
 				Spec: &admin.LaunchPlanSpec{
-					Role: "role-1",
 					WorkflowId: &core.Identifier{
 						Name: "wf",
 					},
 				},
 			},
 			AcceptedAt: acceptedAt,
+			Auth: &admin.AuthRole{
+				AssumableIamRole: "role-1",
+			},
 		})
 
 	assert.Nil(t, err)
@@ -433,12 +444,13 @@ func TestAddPermissions(t *testing.T) {
 	propeller := getFlytePropellerForTest(cluster, &FlyteWorkflowBuilderTest{})
 	flyteWf := v1alpha1.FlyteWorkflow{}
 	propeller.addPermissions(&admin.AuthRole{
-		AssumableIamRole:         "rollie-pollie",
-		KubernetesServiceAccount: "service-account",
+		AssumableIamRole:         testRole,
+		KubernetesServiceAccount: testK8sServiceAccount,
 	}, &flyteWf)
 	assert.EqualValues(t, flyteWf.Annotations, map[string]string{
-		roleNameKey: "rollie-pollie",
+		roleNameKey: testRole,
 	})
+	assert.Equal(t, testK8sServiceAccount, flyteWf.ServiceAccountName)
 }
 
 func TestAddExecutionOverrides(t *testing.T) {

--- a/pkg/workflowengine/interfaces/executor.go
+++ b/pkg/workflowengine/interfaces/executor.go
@@ -20,6 +20,7 @@ type ExecuteWorkflowInput struct {
 	QueueingBudget      time.Duration
 	TaskPluginOverrides []*admin.PluginOverride
 	ExecutionConfig     *admin.WorkflowExecutionConfig
+	Auth                *admin.AuthRole
 }
 
 type ExecuteTaskInput struct {


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
At some point this got deleted and only launch plan roles were read when creating executions...

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1057
https://github.com/flyteorg/flyte/issues/1157
