### PR TITLE
Modify log link merge to take name into account

### DIFF
--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -153,10 +153,10 @@ func mergeLogs(existing, latest []*core.TaskLog) []*core.TaskLog {
 		return latest
 	}
 
-	latestSetByUri := make(map[string]*core.TaskLog, len(latest))
+	latestSetByURI := make(map[string]*core.TaskLog, len(latest))
 	latestSetByName := make(map[string]*core.TaskLog, len(latest))
 	for _, latestLog := range latest {
-		latestSetByUri[latestLog.Uri] = latestLog
+		latestSetByURI[latestLog.Uri] = latestLog
 		if len(latestLog.Name) > 0 {
 			latestSetByName[latestLog.Name] = latestLog
 		}
@@ -165,7 +165,7 @@ func mergeLogs(existing, latest []*core.TaskLog) []*core.TaskLog {
 	// Copy over the latest logs since names will change for existing logs as a task transitions across phases.
 	logs := latest
 	for _, existingLog := range existing {
-		if _, ok := latestSetByUri[existingLog.Uri]; !ok {
+		if _, ok := latestSetByURI[existingLog.Uri]; !ok {
 			if _, ok = latestSetByName[existingLog.Name]; !ok {
 				// We haven't seen this log before: add it to the output result list.
 				logs = append(logs, existingLog)

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -139,26 +139,38 @@ func CreateTaskExecutionModel(input CreateTaskExecutionModelInput) (*models.Task
 	return taskExecution, nil
 }
 
-// Returns the unique list of logs across an existing list and the latest list sent in a task execution event update.
+// mergeLogs returns the unique list of logs across an existing list and the latest list sent in a task execution event
+// update.
+// It returns all the new logs receives + any existing log that hasn't been overwritten by a new log.
+// An existing logLink is said to have been overwritten if a new logLink with the same Uri or the same Name has been
+// received.
 func mergeLogs(existing, latest []*core.TaskLog) []*core.TaskLog {
 	if len(latest) == 0 {
 		return existing
 	}
+
 	if len(existing) == 0 {
 		return latest
 	}
-	latestSet := make(map[string]*core.TaskLog, len(latest))
+
+	latestSetByUri := make(map[string]*core.TaskLog, len(latest))
+	latestSetByName := make(map[string]*core.TaskLog, len(latest))
 	for _, latestLog := range latest {
-		latestSet[latestLog.Uri] = latestLog
+		latestSetByUri[latestLog.Uri] = latestLog
+		latestSetByName[latestLog.Name] = latestLog
 	}
+
 	// Copy over the latest logs since names will change for existing logs as a task transitions across phases.
 	logs := latest
 	for _, existingLog := range existing {
-		if _, ok := latestSet[existingLog.Uri]; !ok {
-			// We haven't seen this log before: add it to the output result list.
-			logs = append(logs, existingLog)
+		if _, ok := latestSetByUri[existingLog.Uri]; !ok {
+			if _, ok = latestSetByName[existingLog.Name]; !ok {
+				// We haven't seen this log before: add it to the output result list.
+				logs = append(logs, existingLog)
+			}
 		}
 	}
+
 	return logs
 }
 

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -157,7 +157,9 @@ func mergeLogs(existing, latest []*core.TaskLog) []*core.TaskLog {
 	latestSetByName := make(map[string]*core.TaskLog, len(latest))
 	for _, latestLog := range latest {
 		latestSetByUri[latestLog.Uri] = latestLog
-		latestSetByName[latestLog.Name] = latestLog
+		if len(latestLog.Name) > 0 {
+			latestSetByName[latestLog.Name] = latestLog
+		}
 	}
 
 	// Copy over the latest logs since names will change for existing logs as a task transitions across phases.

--- a/pkg/repositories/transformers/task_execution_test.go
+++ b/pkg/repositories/transformers/task_execution_test.go
@@ -556,6 +556,51 @@ func TestMergeLogs(t *testing.T) {
 					Name: "name_a",
 				},
 				{
+					Uri:  "uri_b_old",
+					Name: "name_b",
+				},
+				{
+					Uri:  "uri_c",
+					Name: "name_c",
+				},
+			},
+			latest: []*core.TaskLog{
+				{
+					Uri:  "uri_b",
+					Name: "name_b",
+				},
+				{
+					Uri:  "uri_d",
+					Name: "name_d",
+				},
+			},
+			expected: []*core.TaskLog{
+				{
+					Uri:  "uri_b",
+					Name: "name_b",
+				},
+				{
+					Uri:  "uri_d",
+					Name: "name_d",
+				},
+				{
+					Uri:  "uri_a",
+					Name: "name_a",
+				},
+				{
+					Uri:  "uri_c",
+					Name: "name_c",
+				},
+			},
+			name: "Merge unique logs by name",
+		},
+		{
+			existing: []*core.TaskLog{
+				{
+					Uri:  "uri_a",
+					Name: "name_a",
+				},
+				{
 					Uri:  "uri_b",
 					Name: "ignored_name_b",
 				},

--- a/pkg/repositories/transformers/task_execution_test.go
+++ b/pkg/repositories/transformers/task_execution_test.go
@@ -552,6 +552,36 @@ func TestMergeLogs(t *testing.T) {
 		{
 			existing: []*core.TaskLog{
 				{
+					Uri: "uri_a",
+				},
+				{
+					Uri: "uri_b",
+				},
+			},
+			latest: []*core.TaskLog{
+				{
+					Uri: "uri_b",
+				},
+				{
+					Uri: "uri_c",
+				},
+			},
+			expected: []*core.TaskLog{
+				{
+					Uri: "uri_b",
+				},
+				{
+					Uri: "uri_c",
+				},
+				{
+					Uri: "uri_a",
+				},
+			},
+			name: "Merge logs with empty names",
+		},
+		{
+			existing: []*core.TaskLog{
+				{
 					Uri:  "uri_a",
 					Name: "name_a",
 				},


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
When merging log links from event vs existing, only add those with unique URIs and names (previously only URIs were taken into account)

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1185