### PR TITLE
Update Kind to 0.11.1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -50,7 +50,7 @@ jobs:
         run: docker load -i /tmp/tmp/docker-images/snapshot.tar || true
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.10.0"
+          version: "v0.11.1"
       - name: End2End
         run: |
           kubectl cluster-info

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
         run: docker load -i /tmp/tmp/docker-images/snapshot.tar || true
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.10.0"
+          version: "v0.11.1"
       - name: End2End
         run: |
           kubectl cluster-info
@@ -72,7 +72,7 @@ jobs:
         run: docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.10.0"
+          version: "v0.11.1"
       - name: Integration
         run: |
           # attempt to clean up some unneeded data: https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Kind started failing to bring up CNI plugin and causing E2E tests to fail across all repos. We're not sure what caused this but something in the Github environment is probably to blame.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin
