### PR TITLE
Add workflow execution config to attributes_validator.go

### DIFF
--- a/pkg/manager/impl/validation/attributes_validator.go
+++ b/pkg/manager/impl/validation/attributes_validator.go
@@ -28,6 +28,8 @@ func validateMatchingAttributes(attributes *admin.MatchingAttributes, identifier
 		return admin.MatchableResource_EXECUTION_CLUSTER_LABEL, nil
 	} else if attributes.GetPluginOverrides() != nil {
 		return admin.MatchableResource_PLUGIN_OVERRIDE, nil
+	} else if attributes.GetWorkflowExecutionConfig() != nil {
+		return admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG, nil
 	}
 	return defaultMatchableResource, errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 		"Unrecognized matching attributes type for request %s", identifier)

--- a/pkg/manager/impl/validation/attributes_validator_test.go
+++ b/pkg/manager/impl/validation/attributes_validator_test.go
@@ -85,6 +85,18 @@ func TestValidateMatchingAttributes(t *testing.T) {
 			admin.MatchableResource_PLUGIN_OVERRIDE,
 			nil,
 		},
+		{
+			&admin.MatchingAttributes{
+				Target: &admin.MatchingAttributes_WorkflowExecutionConfig{
+					WorkflowExecutionConfig: &admin.WorkflowExecutionConfig{
+						MaxParallelism: 100,
+					},
+				},
+			},
+			"foo",
+			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG,
+			nil,
+		},
 	}
 	for _, tc := range testCases {
 		matchableResource, err := validateMatchingAttributes(tc.attributes, tc.identifier)


### PR DESCRIPTION
# TL;DR
Currently update workflow execution config from flytectl results in rpc errors. Adding workflow execution config to attributes_validator.go should fix this.
`Error: rpc error: code = InvalidArgument desc = Unrecognized matching attributes type for request flytesnacks-development-myapp.workflows.example.my_wf`

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added `MatchableResource_WORKFLOW_EXECUTION_CONFIG` to attributes_validator.go where other matchable attributes get validated.

## Tracking Issue
_NA_

## Follow-up issue
_NA_