### PR TITLE
Apply resource limits on container without rescource

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -224,9 +224,6 @@ func createTaskDefaultLimits(systemResourceLimits runtimeInterfaces.TaskResource
 	if systemResourceLimits.Memory != "" {
 		taskResourceLimits.Memory = systemResourceLimits.Memory
 	}
-	if systemResourceLimits.GPU != "" {
-		taskResourceLimits.GPU = systemResourceLimits.GPU
-	}
 
 	return taskResourceLimits
 }

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -332,10 +332,19 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 		logger.Warningf(ctx, "Can't set default resources for nil task.")
 		return
 	}
-	if task.Template == nil || task.Template.GetContainer() == nil || task.Template.GetContainer().Resources == nil {
+	if task.Template == nil || task.Template.GetContainer() == nil {
 		// Nothing to do
 		logger.Debugf(ctx, "Not setting default resources for task [%+v], no container resources found to check", task)
 		return
+	}
+
+	if task.Template.GetContainer().Resources == nil {
+		// In case of no resources on the container, create empty requests and limits
+		// so the container will still have resources configure properly
+		task.Template.GetContainer().Resources = &core.Resources{
+			Requests: []*core.Resources_ResourceEntry{},
+			Limits:   []*core.Resources_ResourceEntry{},
+		}
 	}
 	resource, err := m.resourceManager.GetResource(ctx, interfaces.ResourceRequest{
 		Project:      task.Template.Id.Project,

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -209,35 +209,12 @@ func (m *ExecutionManager) offloadInputs(ctx context.Context, literalMap *core.L
 	return inputsURI, nil
 }
 
-func createTaskDefaultLimits(ctx context.Context, task *core.CompiledTask,
-	systemResourceLimits runtimeInterfaces.TaskResourceSet) runtimeInterfaces.TaskResourceSet {
+func createTaskDefaultLimits(systemResourceLimits runtimeInterfaces.TaskResourceSet) runtimeInterfaces.TaskResourceSet {
 	// The values below should never be used (deduce it from the request; request should be set by the time we get here).
 	// Setting them here just in case we end up with requests not set. We are not adding to config because it would add
 	// more confusion as its mostly not used.
 	cpuLimit := "500m"
 	memoryLimit := "500Mi"
-	resourceEntries := task.Template.GetContainer().Resources.Requests
-	var cpuIndex, memoryIndex = -1, -1
-	for idx, entry := range resourceEntries {
-		switch entry.Name {
-		case core.Resources_CPU:
-			cpuIndex = idx
-
-		case core.Resources_MEMORY:
-			memoryIndex = idx
-		}
-	}
-
-	if cpuIndex < 0 || memoryIndex < 0 {
-		logger.Errorf(ctx, "Cpu request and Memory request missing for %s", task.Template.Id)
-	}
-
-	if cpuIndex >= 0 {
-		cpuLimit = resourceEntries[cpuIndex].Value
-	}
-	if memoryIndex >= 0 {
-		memoryLimit = resourceEntries[memoryIndex].Value
-	}
 
 	taskResourceLimits := runtimeInterfaces.TaskResourceSet{CPU: cpuLimit, Memory: memoryLimit}
 	// Use the limits from config
@@ -384,7 +361,7 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 		taskResourceSpec = resource.Attributes.GetTaskResourceAttributes().Limits
 	}
 	task.Template.GetContainer().Resources.Limits = assignResourcesIfUnset(
-		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task, m.config.TaskResourceConfiguration().GetLimits()), task.Template.GetContainer().Resources.Limits,
+		ctx, task.Template.Id, createTaskDefaultLimits(m.config.TaskResourceConfiguration().GetLimits()), task.Template.GetContainer().Resources.Limits,
 		taskResourceSpec)
 	checkTaskRequestsLessThanLimits(ctx, task.Template.Id, task.Template.GetContainer().Resources)
 }

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -2719,7 +2719,7 @@ func TestSetDefaults_MissingDefaults(t *testing.T) {
 		task.Template.GetContainer()), fmt.Sprintf("%+v", task.Template.GetContainer()))
 }
 
-func TestCreateTaskDefaultLimitsMissingConfig(t *testing.T) {
+func TestCreateTaskDefaultLimits(t *testing.T) {
 	task := &core.CompiledTask{
 		Template: &core.TaskTemplate{
 			Target: &core.TaskTemplate_Container{
@@ -2747,7 +2747,7 @@ func TestCreateTaskDefaultLimitsMissingConfig(t *testing.T) {
 		assert.Equal(t, "200Mi", defaultLimits.Memory)
 		assert.Equal(t, "200m", defaultLimits.CPU)
 	})
-	t.Run("use_limit", func(t *testing.T) {
+	t.Run("use_limits_from_config", func(t *testing.T) {
 		defaultLimits := createTaskDefaultLimits(context.Background(), task, resourceLimits)
 		assert.Equal(t, "500Gi", defaultLimits.Memory)
 		assert.Equal(t, "300m", defaultLimits.CPU)

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -2742,6 +2742,14 @@ func TestCreateTaskDefaultLimits(t *testing.T) {
 		assert.Equal(t, "500Mi", defaultLimits.Memory)
 		assert.Equal(t, "300m", defaultLimits.CPU)
 	})
+	t.Run("use_limits_from_config", func(t *testing.T) {
+		limits := runtimeInterfaces.TaskResourceSet{
+			Memory: "300Mi",
+		}
+		defaultLimits := createTaskDefaultLimits(limits)
+		assert.Equal(t, "300Mi", defaultLimits.Memory)
+		assert.Equal(t, "500m", defaultLimits.CPU)
+	})
 }
 
 func TestCreateSingleTaskExecution(t *testing.T) {

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -2683,8 +2683,9 @@ func TestSetDefaults_MissingDefaults(t *testing.T) {
 		Memory: "200Gi",
 	}
 	taskConfig.Limits = runtimeInterfaces.TaskResourceSet{
-		CPU: "300m",
-		GPU: "8",
+		CPU:    "300m",
+		GPU:    "8",
+		Memory: "2Gi",
 	}
 	mockConfig := runtimeMocks.NewMockConfigurationProvider(
 		testutils.GetApplicationConfigWithDefaultDomains(), nil, nil, &taskConfig,
@@ -2701,7 +2702,7 @@ func TestSetDefaults_MissingDefaults(t *testing.T) {
 					},
 					{
 						Name:  core.Resources_MEMORY,
-						Value: "200Gi",
+						Value: "2Gi",
 					},
 				},
 				Limits: []*core.Resources_ResourceEntry{
@@ -2711,7 +2712,7 @@ func TestSetDefaults_MissingDefaults(t *testing.T) {
 					},
 					{
 						Name:  core.Resources_MEMORY,
-						Value: "200Gi",
+						Value: "2Gi",
 					},
 				},
 			},
@@ -2720,35 +2721,16 @@ func TestSetDefaults_MissingDefaults(t *testing.T) {
 }
 
 func TestCreateTaskDefaultLimits(t *testing.T) {
-	task := &core.CompiledTask{
-		Template: &core.TaskTemplate{
-			Target: &core.TaskTemplate_Container{
-				Container: &core.Container{
-					Resources: &core.Resources{
-						Requests: []*core.Resources_ResourceEntry{
-							{
-								Name:  core.Resources_CPU,
-								Value: "200m",
-							},
-							{
-								Name:  core.Resources_MEMORY,
-								Value: "200Mi",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+
 	t.Run("missing_limits_in_config", func(t *testing.T) {
 		limits := runtimeInterfaces.TaskResourceSet{}
 
-		defaultLimits := createTaskDefaultLimits(context.Background(), task, limits)
-		assert.Equal(t, "200Mi", defaultLimits.Memory)
-		assert.Equal(t, "200m", defaultLimits.CPU)
+		defaultLimits := createTaskDefaultLimits(limits)
+		assert.Equal(t, "500Mi", defaultLimits.Memory)
+		assert.Equal(t, "500m", defaultLimits.CPU)
 	})
 	t.Run("use_limits_from_config", func(t *testing.T) {
-		defaultLimits := createTaskDefaultLimits(context.Background(), task, resourceLimits)
+		defaultLimits := createTaskDefaultLimits(resourceLimits)
 		assert.Equal(t, "500Gi", defaultLimits.Memory)
 		assert.Equal(t, "300m", defaultLimits.CPU)
 	})
@@ -2756,8 +2738,8 @@ func TestCreateTaskDefaultLimits(t *testing.T) {
 		limits := runtimeInterfaces.TaskResourceSet{
 			CPU: "300m",
 		}
-		defaultLimits := createTaskDefaultLimits(context.Background(), task, limits)
-		assert.Equal(t, "200Mi", defaultLimits.Memory)
+		defaultLimits := createTaskDefaultLimits(limits)
+		assert.Equal(t, "500Mi", defaultLimits.Memory)
 		assert.Equal(t, "300m", defaultLimits.CPU)
 	})
 }

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -2752,6 +2752,14 @@ func TestCreateTaskDefaultLimits(t *testing.T) {
 		assert.Equal(t, "500Gi", defaultLimits.Memory)
 		assert.Equal(t, "300m", defaultLimits.CPU)
 	})
+	t.Run("use_limits_from_config", func(t *testing.T) {
+		limits := runtimeInterfaces.TaskResourceSet{
+			CPU: "300m",
+		}
+		defaultLimits := createTaskDefaultLimits(context.Background(), task, limits)
+		assert.Equal(t, "200Mi", defaultLimits.Memory)
+		assert.Equal(t, "300m", defaultLimits.CPU)
+	})
 }
 
 func TestCreateSingleTaskExecution(t *testing.T) {

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -77,6 +77,17 @@ var requestedAt = time.Now()
 var testCluster = "C1"
 var outputURI = "output uri"
 
+var resourceDefaults = runtimeInterfaces.TaskResourceSet{
+	CPU:    "200m",
+	GPU:    "8",
+	Memory: "200Gi",
+}
+var resourceLimits = runtimeInterfaces.TaskResourceSet{
+	CPU:    "300m",
+	GPU:    "8",
+	Memory: "500Gi",
+}
+
 func getLegacySpec() *admin.ExecutionSpec {
 	executionRequest := testutils.GetExecutionRequest()
 	legacySpec := executionRequest.Spec
@@ -113,7 +124,8 @@ func getMockExecutionsConfigProvider() runtimeInterfaces.Configuration {
 		testutils.GetApplicationConfigWithDefaultDomains(),
 		runtimeMocks.NewMockQueueConfigurationProvider(
 			[]runtimeInterfaces.ExecutionQueue{}, []runtimeInterfaces.WorkflowConfig{}),
-		nil, nil, nil, nil)
+		nil,
+		runtimeMocks.NewMockTaskResourceConfiguration(resourceDefaults, resourceLimits), nil, nil)
 	mockExecutionsConfigProvider.(*runtimeMocks.MockConfigurationProvider).AddRegistrationValidationConfiguration(
 		runtimeMocks.NewMockRegistrationValidationProvider())
 	return mockExecutionsConfigProvider
@@ -419,7 +431,8 @@ func TestCreateExecution_TaggedQueue(t *testing.T) {
 				Tags:   []string{"tag"},
 			},
 		}),
-		nil, nil, nil, nil)
+		nil,
+		runtimeMocks.NewMockTaskResourceConfiguration(resourceDefaults, resourceLimits), nil, nil)
 	configProvider.(*runtimeMocks.MockConfigurationProvider).AddRegistrationValidationConfiguration(
 		runtimeMocks.NewMockRegistrationValidationProvider())
 	mockExecutor := workflowengineMocks.NewMockExecutor()

--- a/pkg/manager/impl/testutils/mock_requests.go
+++ b/pkg/manager/impl/testutils/mock_requests.go
@@ -18,6 +18,13 @@ func GetValidTaskRequest() admin.TaskCreateRequest {
 		},
 		Spec: &admin.TaskSpec{
 			Template: &core.TaskTemplate{
+				Id: &core.Identifier{
+					ResourceType: core.ResourceType_TASK,
+					Project:      "project",
+					Domain:       "domain",
+					Name:         "name",
+					Version:      "version",
+				},
 				Type: "type",
 				Metadata: &core.TaskMetadata{
 					Runtime: &core.RuntimeMetadata{


### PR DESCRIPTION
# TL;DR
In flytekit-java, the reources in task template.container is not set. The result of this is the Pods for tasks all get default as
resources:
      limits:
        cpu: "1"
        memory: 1Gi
      requests:
        cpu: "1"
        memory: 1Gi
These limits are from the flyte propeller container plugin. The default system resource limits are not applied in flyteadmin because of this [line](https://github.com/flyteorg/flyteadmin/blob/ab2087db162412e80a690f09c701aa6da8764d78/pkg/manager/impl/execution_manager.go#L337).

The change in the PR should fix the issue of the containers will set resource default/limit even when the resource for container is not filled.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/#1266

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
