### PR TITLE
Add NodeExecutionPhase.RECOVERED as a terminal phase

### DIFF
--- a/pkg/common/executions.go
+++ b/pkg/common/executions.go
@@ -39,6 +39,7 @@ var terminalNodeExecutionPhases = map[core.NodeExecution_Phase]bool{
 	core.NodeExecution_TIMED_OUT: true,
 	core.NodeExecution_ABORTED:   true,
 	core.NodeExecution_SKIPPED:   true,
+	core.NodeExecution_RECOVERED: true,
 }
 
 var terminalTaskExecutionPhases = map[core.TaskExecution_Phase]bool{


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Missed this in https://github.com/flyteorg/flyteadmin/pull/220 - without this patch we never record the node execution outputs.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1151

## Follow-up issue
_NA_
