### PR TITLE
Make task limits default == platform defaults

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -408,8 +408,9 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	if resource != nil && resource.Attributes != nil && resource.Attributes.GetTaskResourceAttributes() != nil {
 		taskResourceSpec = resource.Attributes.GetTaskResourceAttributes().Limits
 	}
+
 	task.Template.GetContainer().Resources.Limits = assignResourcesIfUnset(
-		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task, m.config.TaskResourceConfiguration().GetLimits()), task.Template.GetContainer().Resources.Limits,
+		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task, m.config.TaskResourceConfiguration().GetDefaults()), task.Template.GetContainer().Resources.Limits,
 		taskResourceSpec)
 	checkTaskRequestsLessThanLimits(ctx, task.Template.Id, task.Template.GetContainer().Resources)
 }

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -277,7 +277,7 @@ func TestCreateExecution(t *testing.T) {
 			for _, task := range tasks {
 				assert.EqualValues(t, resources.Requests,
 					task.Template.GetContainer().Resources.Requests)
-				assert.EqualValues(t, resources.Limits,
+				assert.EqualValues(t, resources.Requests,
 					task.Template.GetContainer().Resources.Limits)
 			}
 			return &workflowengineInterfaces.ExecutionInfo{
@@ -2933,15 +2933,15 @@ func TestSetDefaults(t *testing.T) {
 				Limits: []*core.Resources_ResourceEntry{
 					{
 						Name:  core.Resources_CPU,
-						Value: "300m",
+						Value: "200m",
 					},
 					{
 						Name:  core.Resources_MEMORY,
-						Value: "500Gi",
+						Value: "200Gi",
 					},
 					{
 						Name:  core.Resources_EPHEMERAL_STORAGE,
-						Value: "501Mi",
+						Value: "500Mi",
 					},
 				},
 			},
@@ -3004,7 +3004,7 @@ func TestSetDefaults_MissingDefaults(t *testing.T) {
 				Limits: []*core.Resources_ResourceEntry{
 					{
 						Name:  core.Resources_CPU,
-						Value: "300m",
+						Value: "200m",
 					},
 					{
 						Name:  core.Resources_MEMORY,


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Sets resource limits of tasks with no limits to platform defaults instead of platform limits.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1336