### PR TITLE
Fix Subworkflow auth role

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -610,7 +610,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 
 }
 
-func resolvePermissions(ctx context.Context, request *admin.ExecutionCreateRequest, launchPlan *admin.LaunchPlan) *admin.AuthRole {
+func resolvePermissions(ctx context.Context, launchPlan *admin.LaunchPlan) *admin.AuthRole {
 	authRole := admin.AuthRole{}
 
 	// If we are launching SubWorkflows defined in a different project and domain via dynamic task,
@@ -742,7 +742,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		AcceptedAt:      requestedAt,
 		QueueingBudget:  qualityOfService.QueuingBudget,
 		ExecutionConfig: executionConfig,
-		Auth:            resolvePermissions(ctx, &request, launchPlan),
+		Auth:            resolvePermissions(ctx, launchPlan),
 	}
 	err = m.addLabelsAndAnnotations(request.Spec, &executeWorkflowInputs)
 	if err != nil {

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -612,9 +612,11 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 
 func resolvePermissions(ctx context.Context, request *admin.ExecutionCreateRequest, launchPlan *admin.LaunchPlan) *admin.AuthRole {
 	authRole := admin.AuthRole{}
-	if request.Spec.AuthRole != nil && len(request.Spec.AuthRole.AssumableIamRole) > 0 {
-		authRole.AssumableIamRole = request.Spec.AuthRole.AssumableIamRole
-	} else if launchPlan.GetSpec().GetAuthRole() != nil && len(launchPlan.GetSpec().GetAuthRole().AssumableIamRole) > 0 {
+
+	// If we are launching SubWorkflows defined in a different project and domain via dynamic task,
+	// We want to make sure SubWorkflows are using the auth role defined in their LaunchPlan
+	// instead of the auth role defined in the request (parent's auth role).
+	if launchPlan.GetSpec().GetAuthRole() != nil && len(launchPlan.GetSpec().GetAuthRole().AssumableIamRole) > 0 {
 		authRole.AssumableIamRole = launchPlan.GetSpec().GetAuthRole().AssumableIamRole
 	} else if launchPlan.GetSpec().GetAuth() != nil && len(launchPlan.GetSpec().GetAuth().AssumableIamRole) > 0 {
 		authRole.AssumableIamRole = launchPlan.GetSpec().GetAuth().AssumableIamRole
@@ -624,9 +626,7 @@ func resolvePermissions(ctx context.Context, request *admin.ExecutionCreateReque
 		logger.Warning(ctx, "AssumableIamRole not set.")
 	}
 
-	if request.Spec.AuthRole != nil && len(request.Spec.AuthRole.KubernetesServiceAccount) > 0 {
-		authRole.KubernetesServiceAccount = request.Spec.AuthRole.KubernetesServiceAccount
-	} else if launchPlan.GetSpec().GetAuthRole() != nil && len(launchPlan.GetSpec().GetAuthRole().KubernetesServiceAccount) > 0 {
+	if launchPlan.GetSpec().GetAuthRole() != nil && len(launchPlan.GetSpec().GetAuthRole().KubernetesServiceAccount) > 0 {
 		authRole.KubernetesServiceAccount = launchPlan.GetSpec().GetAuthRole().KubernetesServiceAccount
 	} else if launchPlan.GetSpec().GetAuth() != nil && len(launchPlan.GetSpec().GetAuth().KubernetesServiceAccount) > 0 {
 		authRole.KubernetesServiceAccount = launchPlan.GetSpec().GetAuth().KubernetesServiceAccount

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3203,7 +3203,7 @@ func TestResolvePermissions(t *testing.T) {
 	assumableIamRole := "role"
 	k8sServiceAccount := "sa"
 
-	t.Run("use request values", func(t *testing.T) {
+	t.Run("do not use request values", func(t *testing.T) {
 		auth := resolvePermissions(context.Background(), &admin.ExecutionCreateRequest{
 			Spec: &admin.ExecutionSpec{
 				AuthRole: &admin.AuthRole{
@@ -3219,8 +3219,8 @@ func TestResolvePermissions(t *testing.T) {
 				},
 			},
 		})
-		assert.Equal(t, assumableIamRole, auth.AssumableIamRole)
-		assert.Equal(t, k8sServiceAccount, auth.KubernetesServiceAccount)
+		assert.Equal(t, "lp role", auth.AssumableIamRole)
+		assert.Equal(t, "k8s sa", auth.KubernetesServiceAccount)
 	})
 	t.Run("prefer lp auth role over auth", func(t *testing.T) {
 		auth := resolvePermissions(context.Background(), &admin.ExecutionCreateRequest{

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3204,14 +3204,7 @@ func TestResolvePermissions(t *testing.T) {
 	k8sServiceAccount := "sa"
 
 	t.Run("do not use request values", func(t *testing.T) {
-		auth := resolvePermissions(context.Background(), &admin.ExecutionCreateRequest{
-			Spec: &admin.ExecutionSpec{
-				AuthRole: &admin.AuthRole{
-					AssumableIamRole:         assumableIamRole,
-					KubernetesServiceAccount: k8sServiceAccount,
-				},
-			},
-		}, &admin.LaunchPlan{
+		auth := resolvePermissions(context.Background(), &admin.LaunchPlan{
 			Spec: &admin.LaunchPlanSpec{
 				AuthRole: &admin.AuthRole{
 					AssumableIamRole:         "lp role",
@@ -3223,9 +3216,7 @@ func TestResolvePermissions(t *testing.T) {
 		assert.Equal(t, "k8s sa", auth.KubernetesServiceAccount)
 	})
 	t.Run("prefer lp auth role over auth", func(t *testing.T) {
-		auth := resolvePermissions(context.Background(), &admin.ExecutionCreateRequest{
-			Spec: &admin.ExecutionSpec{},
-		}, &admin.LaunchPlan{
+		auth := resolvePermissions(context.Background(), &admin.LaunchPlan{
 			Spec: &admin.LaunchPlanSpec{
 				AuthRole: &admin.AuthRole{
 					AssumableIamRole:         assumableIamRole,
@@ -3241,9 +3232,7 @@ func TestResolvePermissions(t *testing.T) {
 		assert.Equal(t, k8sServiceAccount, auth.KubernetesServiceAccount)
 	})
 	t.Run("prefer lp auth over role", func(t *testing.T) {
-		auth := resolvePermissions(context.Background(), &admin.ExecutionCreateRequest{
-			Spec: &admin.ExecutionSpec{},
-		}, &admin.LaunchPlan{
+		auth := resolvePermissions(context.Background(), &admin.LaunchPlan{
 			Spec: &admin.LaunchPlanSpec{
 				Auth: &admin.Auth{
 					AssumableIamRole:         assumableIamRole,


### PR DESCRIPTION
If we are launching SubWorkflows defined in a different project and domain via dynamic task,
We want to make sure SubWorkflows are using the auth role defined in their LaunchPlan
instead of the auth role defined in the request (parent's auth role).