### PR TITLE
Fix SubWorkflow auth issues

### DIFF
--- a/pkg/workflowengine/impl/propeller_executor.go
+++ b/pkg/workflowengine/impl/propeller_executor.go
@@ -147,7 +147,7 @@ func (c *FlytePropeller) ExecuteWorkflow(ctx context.Context, input interfaces.E
 	acceptAtWrapper := v1.NewTime(input.AcceptedAt)
 	flyteWf.AcceptedAt = &acceptAtWrapper
 
-	c.addPermissions(input.Auth, flyteWf, input.ExecutionID.GetProject(), input.ExecutionID.GetDomain())
+	c.addPermissions(input.Auth, flyteWf, input.Reference.Id.GetProject(), input.Reference.Id.GetDomain())
 
 	labels := addMapValues(input.Labels, flyteWf.Labels)
 	flyteWf.Labels = labels

--- a/pkg/workflowengine/impl/propeller_executor_test.go
+++ b/pkg/workflowengine/impl/propeller_executor_test.go
@@ -153,7 +153,7 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 				"customlabel": "labelval",
 			}, workflow.Labels)
 			expectedAnnotations := map[string]string{
-				"iam.amazonaws.com/role":  "pbatchworker-d",
+				"iam.amazonaws.com/role":  "lp-pbatchworker-lp-d",
 				"lyft.net/iamwait-inject": "required",
 				"customannotation":        "annotationval",
 			}


### PR DESCRIPTION
This PR fixes the issue with SubWorkflows has incorrect IAM annotations.

Actual:
```
➜ kubectl describe fly f3eobbhi -n flytefunctionaltests-development
Name:         f3eobbhi
Namespace:    flytefunctionaltests-development
Labels:       execution-id=f3eobbhi
              hour-of-day=18
              termination-status=terminated
              workflow-name=tests-common-workflows-simple-simpleworkflow
Annotations:  aws-batch-role: flytefunctionaltestsbatchworker-development-iad
              iam.amazonaws.com/role: flytefunctionaltestsbatchworker-development-iad
```
Expected:
```
➜ kubectl describe fly frbs2cyq -n flytefunctionaltests-development
Name:         frbs2cyq
Namespace:    flytefunctionaltests-development
Labels:       execution-id=frbs2cyq
              hour-of-day=18
              termination-status=terminated
              workflow-name=tests-common-workflows-simple-simpleworkflow
Annotations:  aws-batch-role: flytefunctionaltestsbatchworker-production-iad
              iam.amazonaws.com/role: flytefunctionaltestsbatchworker-production-iad
```

Tested in staging and confirmed that the workflow has the right annotations:
```
➜  kubectl describe fly flbal55y -n flytefunctionaltests-development
Name:         flbal55y
Namespace:    flytefunctionaltests-development
Labels:       execution-id=flbal55y
              hour-of-day=23
              termination-status=terminated
              workflow-name=tests-common-workflows-simple-simpleworkflow
Annotations:  aws-batch-role: flytefunctionaltestsbatchworker-production-iad
              iam.amazonaws.com/role: flytefunctionaltestsbatchworker-production-iad
```