### PR TITLE
Make required scopes configurable #minor

### DIFF
--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -129,8 +129,6 @@ func (p Provider) ValidateAccessToken(ctx context.Context, expectedAudience, tok
 
 	claimsRaw := parsedToken.Claims.(jwtgo.MapClaims)
 
-	verifyClaims(sets.NewString(expectedAudience), claimsRaw)
-
 	return verifyClaims(sets.NewString(expectedAudience), claimsRaw)
 }
 

--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -128,7 +128,6 @@ func (p Provider) ValidateAccessToken(ctx context.Context, expectedAudience, tok
 	}
 
 	claimsRaw := parsedToken.Claims.(jwtgo.MapClaims)
-
 	return verifyClaims(sets.NewString(expectedAudience), claimsRaw)
 }
 

--- a/auth/authzserver/provider_test.go
+++ b/auth/authzserver/provider_test.go
@@ -237,3 +237,26 @@ func Test_verifyClaims(t *testing.T) {
 		assert.Equal(t, "123", identityCtx.UserID())
 	})
 }
+
+func Test_verify_scopes(t *testing.T) {
+
+	t.Run("No required scope", func(t *testing.T) {
+		err := verifyScopes(sets.String{}, sets.String{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("all is all we need", func(t *testing.T) {
+		err := verifyScopes(sets.NewString("a"), sets.NewString("all"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Have all required scopes", func(t *testing.T) {
+		err := verifyScopes(sets.NewString("a", "b"), sets.NewString("a", "b", "c"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Missing required scopes", func(t *testing.T) {
+		err := verifyScopes(sets.NewString("a", "b"), sets.NewString("a", "c"))
+		assert.NotNil(t, err)
+	})
+}

--- a/auth/config/config.go
+++ b/auth/config/config.go
@@ -176,6 +176,7 @@ type ExternalAuthorizationServer struct {
 	BaseURL             config.URL `json:"baseUrl" pflag:",This should be the base url of the authorization server that you are trying to hit. With Okta for instance, it will look something like https://company.okta.com/oauth2/abcdef123456789/"`
 	AllowedAudience     []string   `json:"allowedAudience" pflag:",Optional: A list of allowed audiences. If not provided, the audience is expected to be the public Uri of the service."`
 	MetadataEndpointURL config.URL `json:"metadataUrl" pflag:",Optional: If the server doesn't support /.well-known/oauth-authorization-server, you can set a custom metadata url here.'"`
+	RequiredScopes       []string   `json:"requiredScopes" pflag:",Optional: A list of scopes required to access the resource."`
 }
 
 // OAuth2Options defines settings for app auth.


### PR DESCRIPTION
# TL;DR
Make required scopes configurable.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently `scope: all` is required to access the resource server. However, the external auth server may be shared by other services and we probably don't need to all scopes to access Flyte.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
