### PR TITLE
Hack: allow scope: svc

### DIFF
--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -87,7 +87,10 @@ func blanketAuthorization(ctx context.Context, req interface{}, _ *grpc.UnarySer
 		return handler(ctx, req)
 	}
 
-	if !identityContext.Scopes().Has(auth.ScopeAll) {
+	// HACK: At Lyft, we do not want to scope all since it also exposes other okta resources
+	// that are not necessary for Flyte.
+	scopeSvc := "svc"
+	if !identityContext.Scopes().Has(auth.ScopeAll) && !identityContext.Scopes().Has(scopeSvc) {
 		return nil, status.Errorf(codes.Unauthenticated, "authenticated user doesn't have required scope")
 	}
 


### PR DESCRIPTION
At Lyft, we don't want to grant `scope: all` to the application since it will also give out all other okta api access that is not necessary for flyte auth and we grant `scope: svc` for applications that need to access Flyte.