### PR TITLE
Make Flyte scope all value configurable

### DIFF
--- a/auth/authzserver/metadata_provider.go
+++ b/auth/authzserver/metadata_provider.go
@@ -40,7 +40,7 @@ func (s OAuth2MetadataProvider) GetOAuth2Metadata(ctx context.Context, r *servic
 				"code token",
 			},
 			GrantTypesSupported: supportedGrantTypes,
-			ScopesSupported:     []string{auth.ScopeAll},
+			ScopesSupported:     []string{s.cfg.AppAuth.FlyteScopeAll},
 			TokenEndpointAuthMethodsSupported: []string{
 				"client_secret_basic",
 			},

--- a/auth/authzserver/metadata_provider_test.go
+++ b/auth/authzserver/metadata_provider_test.go
@@ -41,7 +41,7 @@ func TestOAuth2MetadataProvider_OAuth2Metadata(t *testing.T) {
 	t.Run("Self AuthServer", func(t *testing.T) {
 		provider := NewService(&authConfig.Config{
 			AuthorizedURIs: []config2.URL{{URL: *config.MustParseURL("https://issuer/")}},
-			AppAuth: authConfig.OAuth2Options{FlyteScopeAll: "all"},
+			AppAuth:        authConfig.OAuth2Options{FlyteScopeAll: "all"},
 		})
 
 		ctx := context.Background()

--- a/auth/authzserver/metadata_provider_test.go
+++ b/auth/authzserver/metadata_provider_test.go
@@ -41,12 +41,14 @@ func TestOAuth2MetadataProvider_OAuth2Metadata(t *testing.T) {
 	t.Run("Self AuthServer", func(t *testing.T) {
 		provider := NewService(&authConfig.Config{
 			AuthorizedURIs: []config2.URL{{URL: *config.MustParseURL("https://issuer/")}},
+			AppAuth: authConfig.OAuth2Options{FlyteScopeAll: "all"},
 		})
 
 		ctx := context.Background()
 		resp, err := provider.GetOAuth2Metadata(ctx, &service.OAuth2MetadataRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, "https://issuer/", resp.Issuer)
+		assert.Equal(t, "all", resp.ScopesSupported[0])
 	})
 
 	var issuer string

--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -45,9 +45,9 @@ const (
 // Provider implements OAuth2 Authorization Server.
 type Provider struct {
 	fosite.OAuth2Provider
-	cfg       config.AuthorizationServer
-	publicKey []rsa.PublicKey
-	keySet    jwk.Set
+	cfg           config.AuthorizationServer
+	publicKey     []rsa.PublicKey
+	keySet        jwk.Set
 	flyteScopeAll string
 }
 

--- a/auth/authzserver/provider_test.go
+++ b/auth/authzserver/provider_test.go
@@ -237,7 +237,7 @@ func Test_verifyClaims(t *testing.T) {
 		assert.Equal(t, "123", identityCtx.UserID())
 	})
 
-	t.Run("Add flyte scope all if it is user access token iwth no scope defined", func(t *testing.T) {
+	t.Run("Add flyte scope all if it is user access token with no scope defined", func(t *testing.T) {
 		identityCtx, err := verifyClaims(sets.NewString("https://myserver"), map[string]interface{}{
 			"aud": []string{"https://myserver"},
 			"user_info": map[string]interface{}{

--- a/auth/authzserver/provider_test.go
+++ b/auth/authzserver/provider_test.go
@@ -236,4 +236,19 @@ func Test_verifyClaims(t *testing.T) {
 		assert.Equal(t, "my-client", identityCtx.AppID())
 		assert.Equal(t, "123", identityCtx.UserID())
 	})
+
+	t.Run("Add flyte scope all if it is user access token iwth no scope defined", func(t *testing.T) {
+		identityCtx, err := verifyClaims(sets.NewString("https://myserver"), map[string]interface{}{
+			"aud": []string{"https://myserver"},
+			"user_info": map[string]interface{}{
+				"preferred_name": "John Doe",
+			},
+			"sub":       "123",
+			"client_id": "",
+			"scp":       []interface{}{},
+		}, "all")
+
+		assert.NoError(t, err)
+		assert.Equal(t, sets.NewString("all"), identityCtx.Scopes())
+	})
 }

--- a/auth/authzserver/provider_test.go
+++ b/auth/authzserver/provider_test.go
@@ -39,7 +39,7 @@ func newMockProvider(t testing.TB) (Provider, auth.SecretsSet) {
 	sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return(buf.String(), nil)
 	sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return("", fmt.Errorf("not found"))
 
-	p, err := NewProvider(ctx, config.DefaultConfig.AppAuth.SelfAuthServer, sm)
+	p, err := NewProvider(ctx, config.DefaultConfig.AppAuth, sm)
 	assert.NoError(t, err)
 	return p, secrets
 }
@@ -180,7 +180,7 @@ func TestProvider_ValidateAccessToken(t *testing.T) {
 		sm.OnGet(ctx, config.SecretNameTokenSigningRSAKey).Return(buf.String(), nil)
 		sm.OnGet(ctx, config.SecretNameOldTokenSigningRSAKey).Return("", fmt.Errorf("not found"))
 
-		p, err := NewProvider(ctx, config.DefaultConfig.AppAuth.SelfAuthServer, sm)
+		p, err := NewProvider(ctx, config.DefaultConfig.AppAuth, sm)
 		assert.NoError(t, err)
 
 		// create a signer for rsa 256
@@ -216,7 +216,7 @@ func TestProvider_ValidateAccessToken(t *testing.T) {
 
 func Test_verifyClaims(t *testing.T) {
 	t.Run("Empty claims, fail", func(t *testing.T) {
-		_, err := verifyClaims(sets.NewString("https://myserver"), map[string]interface{}{})
+		_, err := verifyClaims(sets.NewString("https://myserver"), map[string]interface{}{}, "all")
 		assert.Error(t, err)
 	})
 
@@ -229,7 +229,7 @@ func Test_verifyClaims(t *testing.T) {
 			"sub":       "123",
 			"client_id": "my-client",
 			"scp":       []interface{}{"all", "offline"},
-		})
+		}, "all")
 
 		assert.NoError(t, err)
 		assert.Equal(t, sets.NewString("all", "offline"), identityCtx.Scopes())

--- a/auth/authzserver/resource_server_test.go
+++ b/auth/authzserver/resource_server_test.go
@@ -67,9 +67,13 @@ func newMockResourceServer(t testing.TB) ResourceServer {
 
 	http.DefaultClient = s.Client()
 
-	r, err := NewOAuth2ResourceServer(ctx, authConfig.ExternalAuthorizationServer{
-		BaseURL: stdlibConfig.URL{URL: *config.MustParseURL(s.URL)},
-	}, stdlibConfig.URL{})
+	options := authConfig.OAuth2Options{
+		ExternalAuthServer: authConfig.ExternalAuthorizationServer{
+			BaseURL: stdlibConfig.URL{URL: *config.MustParseURL(s.URL)},
+		},
+	}
+
+	r, err := NewOAuth2ResourceServer(ctx, options, stdlibConfig.URL{})
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/auth/config/config.go
+++ b/auth/config/config.go
@@ -183,6 +183,8 @@ type OAuth2Options struct {
 	// AuthServerType defines the type of AuthServer to connect to.
 	AuthServerType AuthorizationServerType `json:"authServerType" pflag:"-,Determines authorization server type to use. Additional config should be provided for the chosen AuthorizationServer"`
 
+	FlyteScopeAll string `json:"flyteScopeAll" pflag:", Name of the scope that allows access to all Flyte resources. By default the name is 'all'."`
+
 	// SelfAuthServer defines settings for running authorization server locally.
 	SelfAuthServer AuthorizationServer `json:"selfAuthServer" pflag:",Authorization Server config to run as a service. Use this when using an IdP that does not offer a custom OAuth2 Authorization Server."`
 

--- a/auth/config/config.go
+++ b/auth/config/config.go
@@ -69,6 +69,7 @@ var (
 		},
 		AppAuth: OAuth2Options{
 			AuthServerType: AuthorizationServerTypeSelf,
+			FlyteScopeAll: "all",
 			ThirdParty: ThirdPartyConfigOptions{
 				FlyteClientConfig: FlyteClientConfig{
 					ClientID:    "flytectl",

--- a/auth/config/config.go
+++ b/auth/config/config.go
@@ -69,7 +69,7 @@ var (
 		},
 		AppAuth: OAuth2Options{
 			AuthServerType: AuthorizationServerTypeSelf,
-			FlyteScopeAll: "all",
+			FlyteScopeAll:  "all",
 			ThirdParty: ThirdPartyConfigOptions{
 				FlyteClientConfig: FlyteClientConfig{
 					ClientID:    "flytectl",

--- a/auth/constants.go
+++ b/auth/constants.go
@@ -20,5 +20,4 @@ const (
 	OIdCMetadataEndpoint = ".well-known/openid-configuration"
 
 	ContextKeyIdentityContext = contextutils.Key("identity_context")
-	ScopeAll                  = "all"
 )

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -236,8 +236,7 @@ func GetAuthenticationInterceptor(authCtx interfaces.AuthenticationContext) func
 
 		logger.Infof(ctx, "Failed to parse Access Token from context. Will attempt to find IDToken. Error: %v", err)
 
-		identityContext, err = GRPCGetIdentityFromIDToken(ctx, authCtx.Options().UserAuth.OpenID.ClientID,
-			authCtx.OidcProvider())
+		identityContext, err = GRPCGetIdentityFromIDToken(ctx, authCtx)
 
 		if err == nil {
 			return SetContextForIdentity(ctx, identityContext), nil
@@ -363,7 +362,7 @@ func IdentityContextFromRequest(ctx context.Context, req *http.Request, authCtx 
 	}
 
 	return IdentityContextFromIDTokenToken(ctx, idToken, authCtx.Options().UserAuth.OpenID.ClientID,
-		authCtx.OidcProvider(), userInfo)
+		authCtx.OidcProvider(), userInfo, authCtx.Options().AppAuth.FlyteScopeAll)
 }
 
 func QueryUserInfo(ctx context.Context, identityContext interfaces.IdentityContext, request *http.Request,

--- a/auth/token.go
+++ b/auth/token.go
@@ -99,8 +99,8 @@ func GRPCGetIdentityFromAccessToken(ctx context.Context, authCtx interfaces.Auth
 func GRPCGetIdentityFromIDToken(ctx context.Context, authCtx interfaces.AuthenticationContext) (
 	interfaces.IdentityContext, error) {
 
-	clientID :=      authCtx.Options().UserAuth.OpenID.ClientID
-	provider :=	     authCtx.OidcProvider()
+	clientID := authCtx.Options().UserAuth.OpenID.ClientID
+	provider := authCtx.OidcProvider()
 	tokenStr, err := grpcauth.AuthFromMD(ctx, IDTokenScheme)
 	if err != nil {
 		logger.Debugf(ctx, "Could not retrieve id token from metadata %v", err)

--- a/auth/token.go
+++ b/auth/token.go
@@ -99,8 +99,8 @@ func GRPCGetIdentityFromAccessToken(ctx context.Context, authCtx interfaces.Auth
 func GRPCGetIdentityFromIDToken(ctx context.Context, authCtx interfaces.AuthenticationContext) (
 	interfaces.IdentityContext, error) {
 
-	clientID := authCtx.Options().UserAuth.OpenID.ClientID
-	provider :=	authCtx.OidcProvider()
+	clientID :=      authCtx.Options().UserAuth.OpenID.ClientID
+	provider :=	     authCtx.OidcProvider()
 	tokenStr, err := grpcauth.AuthFromMD(ctx, IDTokenScheme)
 	if err != nil {
 		logger.Debugf(ctx, "Could not retrieve id token from metadata %v", err)


### PR DESCRIPTION
Signed-off-by: Chao-Han Tsai <milton0825@gmail.com>

# TL;DR
Currently Flyteadmin requires `scope: all` to access the resources, this PR makes the scope name configurable. For example, we can make it `scope: flyte.all` or any other value

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
