### PR TITLE
Change all to svc

### DIFF
--- a/auth/constants.go
+++ b/auth/constants.go
@@ -20,5 +20,5 @@ const (
 	OIdCMetadataEndpoint = ".well-known/openid-configuration"
 
 	ContextKeyIdentityContext = contextutils.Key("identity_context")
-	ScopeAll                  = "all"
+	ScopeAll                  = "svc"
 )

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -87,7 +87,7 @@ func blanketAuthorization(ctx context.Context, req interface{}, _ *grpc.UnarySer
 		return handler(ctx, req)
 	}
 
-	if !identityContext.Scopes().Has(auth.ScopeAll) {
+	if !identityContext.Scopes().Has(auth.ScopeAll) || !identityContext.Scopes().Has("all") {
 		return nil, status.Errorf(codes.Unauthenticated, "authenticated user doesn't have required scope")
 	}
 


### PR DESCRIPTION
At Lyft, we require all applications to request for `scope: svc` so changing the required scope from all to svc to satisfy lyft's setup.