### PR TITLE
Handling empty inputUri for start-node and any node which doesn't have inputs

### DIFF
--- a/pkg/manager/impl/node_execution_manager.go
+++ b/pkg/manager/impl/node_execution_manager.go
@@ -437,9 +437,12 @@ func (m *NodeExecutionManager) GetNodeExecutionData(
 		logger.Debugf(ctx, "failed to transform node execution model [%+v] when fetching data: %v", request.Id, err)
 		return nil, err
 	}
-	signedInputsURLBlob, err := m.urlData.Get(ctx, nodeExecution.InputUri)
-	if err != nil {
-		return nil, err
+	signedInputsURLBlob := admin.UrlBlob{}
+	if nodeExecution.InputUri != "" {
+		signedInputsURLBlob, err = m.urlData.Get(ctx, nodeExecution.InputUri)
+		if err != nil {
+			return nil, err
+		}
 	}
 	signedOutputsURLBlob := admin.UrlBlob{}
 	if nodeExecution.Closure.GetOutputUri() != "" {

--- a/pkg/manager/impl/util/data.go
+++ b/pkg/manager/impl/util/data.go
@@ -8,7 +8,7 @@ import (
 
 func ShouldFetchData(config *interfaces.RemoteDataConfig, urlBlob admin.UrlBlob) bool {
 	return config.Scheme == common.Local || config.Scheme == common.None || config.MaxSizeInBytes == 0 ||
-		urlBlob.Bytes < config.MaxSizeInBytes
+		(len(urlBlob.Url) > 0 && urlBlob.Bytes < config.MaxSizeInBytes)
 }
 
 func ShouldFetchOutputData(config *interfaces.RemoteDataConfig, urlBlob admin.UrlBlob, outputURI string) bool {

--- a/pkg/manager/impl/util/data_test.go
+++ b/pkg/manager/impl/util/data_test.go
@@ -15,6 +15,7 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.Local,
 			MaxSizeInBytes: 100,
 		}, admin.UrlBlob{
+			Url: "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -23,6 +24,7 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.None,
 			MaxSizeInBytes: 100,
 		}, admin.UrlBlob{
+			Url: "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -30,6 +32,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.True(t, ShouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme: common.None,
 		}, admin.UrlBlob{
+			Url: "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -38,10 +41,20 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
 		}, admin.UrlBlob{
+			Url: "s3://data",
 			Bytes: 200,
 		}))
 	})
 	t.Run("max size over limit", func(t *testing.T) {
+		assert.False(t, ShouldFetchData(&interfaces.RemoteDataConfig{
+			Scheme:         common.AWS,
+			MaxSizeInBytes: 100,
+		}, admin.UrlBlob{
+			Url: "s3://data",
+			Bytes: 200,
+		}))
+	})
+	t.Run("empty url config", func(t *testing.T) {
 		assert.False(t, ShouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 100,

--- a/pkg/manager/impl/util/data_test.go
+++ b/pkg/manager/impl/util/data_test.go
@@ -15,7 +15,7 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.Local,
 			MaxSizeInBytes: 100,
 		}, admin.UrlBlob{
-			Url: "s3://data",
+			Url:   "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -24,7 +24,7 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.None,
 			MaxSizeInBytes: 100,
 		}, admin.UrlBlob{
-			Url: "s3://data",
+			Url:   "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -32,7 +32,7 @@ func TestShouldFetchData(t *testing.T) {
 		assert.True(t, ShouldFetchData(&interfaces.RemoteDataConfig{
 			Scheme: common.None,
 		}, admin.UrlBlob{
-			Url: "s3://data",
+			Url:   "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -41,7 +41,7 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
 		}, admin.UrlBlob{
-			Url: "s3://data",
+			Url:   "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -50,7 +50,7 @@ func TestShouldFetchData(t *testing.T) {
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 100,
 		}, admin.UrlBlob{
-			Url: "s3://data",
+			Url:   "s3://data",
 			Bytes: 200,
 		}))
 	})
@@ -70,6 +70,7 @@ func TestShouldFetchOutputData(t *testing.T) {
 			Scheme:         common.Local,
 			MaxSizeInBytes: 100,
 		}, admin.UrlBlob{
+			Url:   "s3://data",
 			Bytes: 200,
 		}, "s3://foo/bar.txt"))
 	})
@@ -78,6 +79,7 @@ func TestShouldFetchOutputData(t *testing.T) {
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
 		}, admin.UrlBlob{
+			Url:   "s3://data",
 			Bytes: 200,
 		}, "s3://foo/bar.txt"))
 	})
@@ -86,6 +88,7 @@ func TestShouldFetchOutputData(t *testing.T) {
 			Scheme:         common.AWS,
 			MaxSizeInBytes: 1000,
 		}, admin.UrlBlob{
+			Url:   "s3://data",
 			Bytes: 200,
 		}, ""))
 	})


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

## _Read then delete this section_

# TL;DR
Handling the empty InputUri for any node event while doing get
We will fetch it from the storage only if its non-empty . 

```
[
	{
		"node_exec": {
			"id": {
				"nodeId": "start-node",
				"executionId": {
					"project": "flytesnacks",
					"domain": "development",
					"name": "fdbbaa49c298c4bb48ad"
				}
			},
			"closure": {
				"outputUri": "s3://my-s3-bucket/metadata/propeller/sandbox/flytesnacks-development-fdbbaa49c298c4bb48ad/start-node/data/0/outputs.pb",
				"phase": "SUCCEEDED",
				"createdAt": "2021-09-14T11:51:04.355307Z",
				"updatedAt": "2021-09-14T11:51:04.355307Z"
			},
			"metadata": {
				"specNodeId": "start-node"
			}
		},
		"outputs": {
			"am": true,
			"day_of_week": "Sunday",
			"number": 5
		}
	}
]
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1221
## Follow-up issue
_NA_

