### PR TITLE
Validate launch plan labels are k8s compliant

### DIFF
--- a/pkg/manager/impl/launch_plan_manager_test.go
+++ b/pkg/manager/impl/launch_plan_manager_test.go
@@ -241,6 +241,20 @@ func TestLaunchPlan_ValidationError(t *testing.T) {
 	assert.Nil(t, response)
 }
 
+func TestLaunchPlanManager_CreateLaunchPlanErrorDueToBadLabels(t *testing.T) {
+	repository := getMockRepositoryForLpTest()
+	lpManager := NewLaunchPlanManager(repository, getMockConfigForLpTest(), mockScheduler, mockScope.NewTestScope())
+	request := testutils.GetLaunchPlanRequest()
+	request.Spec.Labels = &admin.Labels{
+		Values: map[string]string{
+			"foo": "#badlabel",
+			"bar": "baz",
+		}}
+	response, err := lpManager.CreateLaunchPlan(context.Background(), request)
+	assert.EqualError(t, err, "invalid label value [#badlabel]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]")
+	assert.Nil(t, response)
+}
+
 func TestLaunchPlan_DatabaseError(t *testing.T) {
 	repository := getMockRepositoryForLpTest()
 	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetGetCallback(

--- a/pkg/manager/impl/validation/launch_plan_validator.go
+++ b/pkg/manager/impl/validation/launch_plan_validator.go
@@ -30,6 +30,9 @@ func ValidateLaunchPlan(ctx context.Context,
 	if err := ValidateIdentifier(request.Spec.WorkflowId, common.Workflow); err != nil {
 		return err
 	}
+	if err := validateLabels(request.Spec.Labels); err != nil {
+		return err
+	}
 
 	if err := validateLiteralMap(request.Spec.FixedInputs, shared.FixedInputs); err != nil {
 		return err

--- a/pkg/manager/impl/validation/launch_plan_validator_test.go
+++ b/pkg/manager/impl/validation/launch_plan_validator_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
+
 	"github.com/flyteorg/flyteidl/clients/go/coreutils"
 
 	"github.com/flyteorg/flyteadmin/pkg/manager/impl/testutils"
@@ -36,6 +38,17 @@ func TestValidateLpEmptyName(t *testing.T) {
 	request.Id.Name = ""
 	err := ValidateLaunchPlan(context.Background(), request, testutils.GetRepoWithDefaultProject(), lpApplicationConfig, getWorkflowInterface())
 	assert.EqualError(t, err, "missing name")
+}
+
+func TestValidateLpLabels(t *testing.T) {
+	request := testutils.GetLaunchPlanRequest()
+	request.Spec.Labels = &admin.Labels{
+		Values: map[string]string{
+			"foo": "#badlabel",
+			"bar": "baz",
+		}}
+	err := ValidateLaunchPlan(context.Background(), request, testutils.GetRepoWithDefaultProject(), lpApplicationConfig, getWorkflowInterface())
+	assert.EqualError(t, err, "invalid label value [#badlabel]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]")
 }
 
 func TestValidateLpEmptyVersion(t *testing.T) {

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -1,9 +1,10 @@
 package validation
 
 import (
-	"k8s.io/apimachinery/pkg/util/validation"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	"github.com/flyteorg/flyteadmin/pkg/errors"

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -57,7 +57,7 @@ func validateLabels(labels *admin.Labels) error {
 	return nil
 }
 
-// Given an admin.Project, checks if the project has labels and if it does, checks if the labels are K8s compliant,
+// Given an admin.Labels, checks if the labels exist, checks if the labels are K8s compliant,
 // i.e. alphanumeric + - and _
 func validateLabelsAlphanumeric(labels *admin.Labels) error {
 	for key, value := range labels.Values {

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -57,7 +57,7 @@ func validateLabels(labels *admin.Labels) error {
 	return nil
 }
 
-// Given an admin.Labels, checks if the labels exist, checks if the labels are K8s compliant,
+// Given an admin.Labels, checks if the labels exist or not and if it does, checks if the labels are K8s compliant,
 // i.e. alphanumeric + - and _
 func validateLabelsAlphanumeric(labels *admin.Labels) error {
 	for key, value := range labels.Values {

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"k8s.io/apimachinery/pkg/util/validation"
 	"strconv"
 	"strings"
 
@@ -38,6 +39,33 @@ func ValidateMaxLengthStringField(field string, fieldName string, limit int) err
 func ValidateMaxMapLengthField(m map[string]string, fieldName string, limit int) error {
 	if len(m) > limit {
 		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "%s map cannot exceed %d entries", fieldName, limit)
+	}
+	return nil
+}
+
+func validateLabels(labels *admin.Labels) error {
+	if labels == nil || len(labels.Values) == 0 {
+		return nil
+	}
+	if err := ValidateMaxMapLengthField(labels.Values, "labels", maxLabelArrayLength); err != nil {
+		return err
+	}
+	if err := validateLabelsAlphanumeric(labels); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Given an admin.Project, checks if the project has labels and if it does, checks if the labels are K8s compliant,
+// i.e. alphanumeric + - and _
+func validateLabelsAlphanumeric(labels *admin.Labels) error {
+	for key, value := range labels.Values {
+		if errs := validation.IsDNS1123Label(key); len(errs) > 0 {
+			return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid label key [%s]: %v", key, errs)
+		}
+		if errs := validation.IsDNS1123Label(value); len(errs) > 0 {
+			return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid label value [%s]: %v", value, errs)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Launch plan labels come from user-provided input values and should be validated.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
- Move validation function in `pkg/manager/impl/validation/project_validator.go` to `pkg/manager/impl/validation/validation.go`
- validate launch plan labels are k8s compliant

## Tracking Issue
https://github.com/flyteorg/flyte/issues/624

## Follow-up issue
_NA_