### PR TITLE
Added precheck for scheduler

### DIFF
--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -125,7 +125,6 @@ func newGRPCServer(ctx context.Context, cfg *config.ServerConfig, authCtx interf
 	healthServer := health.NewServer()
 	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
-
 	if cfg.GrpcServerReflection {
 		reflection.Register(grpcServer)
 	}

--- a/cmd/scheduler/entrypoints/precheck.go
+++ b/cmd/scheduler/entrypoints/precheck.go
@@ -3,40 +3,77 @@ package entrypoints
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/flyteorg/flytestdlib/logger"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
 	"github.com/avast/retry-go"
 	adminClient "github.com/flyteorg/flyteidl/clients/go/admin"
 	"github.com/pkg/errors"
-	"net/http"
-	"strings"
-	"time"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	timeout = 30 * time.Second
 )
 
 var preCheckRunCmd = &cobra.Command{
 	Use:   "precheck",
 	Short: "This command will check pre requirement for scheduler",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		opts := []grpc.DialOption{
+			grpc.WithUserAgent("grpc_health_probe"),
+			grpc.WithBlock(),
+			grpc.WithInsecure(),
+		}
 		ctx := context.Background()
+		config := adminClient.GetConfig(ctx)
+
 		err := retry.Do(
 			func() error {
-				config := adminClient.GetConfig(ctx)
-				host := strings.Split(config.Endpoint.Host, ":")
-				response, err := http.Get(fmt.Sprintf("http://%s/healthcheck", host))
+				dialCtx, dialCancel := context.WithTimeout(ctx, timeout)
+				defer dialCancel()
+				conn, err := grpc.DialContext(dialCtx, config.Endpoint.String(), opts...)
 				if err != nil {
+					if err == context.DeadlineExceeded {
+						logger.Printf(ctx, "timeout: failed to connect service %q within %v", config.Endpoint.String(), timeout)
+						return fmt.Errorf("timeout: failed to connect service %q within %v", config.Endpoint.String(), timeout)
+					}
+					logger.Printf(ctx, "error: failed to connect service at %q: %+v", config.Endpoint.String(), err)
+					return fmt.Errorf("error: failed to connect service at %q: %+v", config.Endpoint.String(), err)
+				}
+				rpcCtx := metadata.NewOutgoingContext(ctx, metadata.MD{})
+				resp, err := healthpb.NewHealthClient(conn).Check(rpcCtx,
+					&healthpb.HealthCheckRequest{
+						Service: "",
+					})
+				if err != nil {
+					if stat, ok := status.FromError(err); ok && stat.Code() == codes.Unimplemented {
+						return retry.Unrecoverable(err)
+					} else if stat, ok := status.FromError(err); ok && stat.Code() == codes.DeadlineExceeded {
+						logger.Printf(ctx, "timeout: health rpc did not complete within %v", timeout)
+						return fmt.Errorf("timeout: health rpc did not complete within %v", timeout)
+					}
 					return err
 				}
-				if response.StatusCode == 200 {
-					return nil
+				if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+					return errors.New("Health check failed")
 				}
-				return errors.New("something goes wrong")
+				return nil
 			},
-			retry.Delay(30*time.Second),
-			retry.Attempts(100),
+			retry.Delay(retry.BackOffDelay(10, nil, &retry.Config{})),
 		)
 		if err != nil {
 			return err
 		}
+
+		logger.Printf(ctx, "Flyteadmin is up & running")
 		return nil
 	},
 }

--- a/cmd/scheduler/entrypoints/precheck.go
+++ b/cmd/scheduler/entrypoints/precheck.go
@@ -21,8 +21,8 @@ var preCheckRunCmd = &cobra.Command{
 		err := retry.Do(
 			func() error {
 				config := adminClient.GetConfig(ctx)
-				host := strings.Split(config.Endpoint.Host,":")
-				response,err := http.Get(fmt.Sprintf("http://%s/healthcheck",host))
+				host := strings.Split(config.Endpoint.Host, ":")
+				response, err := http.Get(fmt.Sprintf("http://%s/healthcheck", host))
 				if err != nil {
 					return err
 				}

--- a/cmd/scheduler/entrypoints/precheck.go
+++ b/cmd/scheduler/entrypoints/precheck.go
@@ -1,0 +1,46 @@
+package entrypoints
+
+import (
+	"context"
+	"github.com/avast/retry-go"
+	adminClient "github.com/flyteorg/flyteidl/clients/go/admin"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flytestdlib/logger"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+)
+
+var preCheckRunCmd = &cobra.Command{
+	Use:   "precheck",
+	Short: "This command will check pre requirement for scheduler",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		err := retry.Do(
+			func() error {
+				clientSet, err := adminClient.ClientSetBuilder().WithConfig(adminClient.GetConfig(ctx)).Build(ctx)
+				if err != nil {
+					logger.Fatalf(ctx, "Flyte native scheduler failed to start due to %v", err)
+					return err
+				}
+				version, err := clientSet.AdminClient().GetVersion(ctx, &admin.GetVersionRequest{})
+				if err != nil {
+					return err
+				}
+				if len(version.ControlPlaneVersion.Version) > 0 {
+					return nil
+				}
+				return errors.New("something goes wrong")
+			},
+		)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(preCheckRunCmd)
+}

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	entrypoints2 "github.com/flyteorg/flyteadmin/cmd/scheduler/entrypoints"
+	"github.com/flyteorg/flyteadmin/cmd/scheduler/entrypoints"
 	"github.com/golang/glog"
 )
 
 func main() {
 	glog.V(2).Info("Beginning Flyte Scheduler")
-	err := entrypoints2.Execute()
+	err := entrypoints.Execute()
 	if err != nil {
 		panic(err)
 	}

--- a/flyteadmin_config.yaml
+++ b/flyteadmin_config.yaml
@@ -206,5 +206,3 @@ qualityOfService:
     # by default production has an UNDEFINED tier when it is omitted from the configuration
 namespace_mapping:
    template: "{{ project }}-{{ domain }}" # Default namespace mapping template.
-admin:
-  endpoint: "dns:///localhost:30081"

--- a/flyteadmin_config.yaml
+++ b/flyteadmin_config.yaml
@@ -206,3 +206,5 @@ qualityOfService:
     # by default production has an UNDEFINED tier when it is omitted from the configuration
 namespace_mapping:
    template: "{{ project }}-{{ domain }}" # Default namespace mapping template.
+admin:
+  endpoint: "dns:///localhost:30081"

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
 	github.com/NYTimes/gizmo v1.3.6
 	github.com/Selvatico/go-mocket v1.0.7
-	github.com/avast/retry-go v3.0.0+incompatible // indirect
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.37.31
 	github.com/benbjohnson/clock v1.1.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
-	github.com/flyteorg/flyteidl v0.20.2
+	github.com/flyteorg/flyteidl v0.19.22
 	github.com/flyteorg/flyteplugins v0.5.72
 	github.com/flyteorg/flytepropeller v0.13.20
 	github.com/flyteorg/flytestdlib v0.3.34

--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,14 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
 	github.com/NYTimes/gizmo v1.3.6
 	github.com/Selvatico/go-mocket v1.0.7
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/aws/aws-sdk-go v1.37.31
 	github.com/benbjohnson/clock v1.1.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
-	github.com/flyteorg/flyteidl v0.19.22
+	github.com/flyteorg/flyteidl v0.20.2
 	github.com/flyteorg/flyteplugins v0.5.72
 	github.com/flyteorg/flytepropeller v0.13.20
 	github.com/flyteorg/flytestdlib v0.3.34

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,6 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flyteorg/flyteidl v0.19.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteidl v0.19.22 h1:e3M0Dob/r5n+AJfAByzad/svMAVes7XfZVxUNCi6AeQ=
 github.com/flyteorg/flyteidl v0.19.22/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
-github.com/flyteorg/flyteidl v0.20.2 h1:3DDj1y9Axmb35SskN/h2nRgohWhGBPGxmJSX7b/Y2rk=
-github.com/flyteorg/flyteidl v0.20.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.5.72 h1:mtbpn4nuFrhZ2DadUlLxjK2RQ9FBFqDf0LaXVpe2hyY=
 github.com/flyteorg/flyteplugins v0.5.72/go.mod h1:YjahYP+i4/Qn+dFvxMOGbhDtkQT4EiH4Kb88KNK505A=
 github.com/flyteorg/flytepropeller v0.13.20 h1:nxQs6eVxloZI7g+YWOFUP9Ro00XNyR5dB+xt+xc04oc=

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d/go.mod h1:mZUP7GJmjiWtf8v3FD1X/QdK08BqyeH/1Ejt0qhNzCs=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.23.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -310,6 +312,8 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flyteorg/flyteidl v0.19.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteidl v0.19.22 h1:e3M0Dob/r5n+AJfAByzad/svMAVes7XfZVxUNCi6AeQ=
 github.com/flyteorg/flyteidl v0.19.22/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.20.2 h1:3DDj1y9Axmb35SskN/h2nRgohWhGBPGxmJSX7b/Y2rk=
+github.com/flyteorg/flyteidl v0.20.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.5.72 h1:mtbpn4nuFrhZ2DadUlLxjK2RQ9FBFqDf0LaXVpe2hyY=
 github.com/flyteorg/flyteplugins v0.5.72/go.mod h1:YjahYP+i4/Qn+dFvxMOGbhDtkQT4EiH4Kb88KNK505A=
 github.com/flyteorg/flytepropeller v0.13.20 h1:nxQs6eVxloZI7g+YWOFUP9Ro00XNyR5dB+xt+xc04oc=
@@ -1441,7 +1445,6 @@ go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -2082,7 +2085,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.0.0-20210217171935-8e2decd92398/go.mod h1:60tmSUpHxGPFerNHbo/ayI2lKxvtrhbxFyXuEIWJd78=


### PR DESCRIPTION
# TL;DR
Flytescheduler has a dependency on flyteadmin. flytescheduler will fail if flyteadmin is not available....it will use as an init container for scheduler deployment 

- Added a new command in scheduler to check flyteadmin health 


Pre request: https://github.com/flyteorg/flyte/pull/1374

Test With Sandbox :
```bash
$ flytectl sandbox start
$ Clone & checkout the PR https://github.com/flyteorg/flyte/pull/1374
$ cd charts/flyte
$ changes flytescheduler image to `evalsocket/flytescheduler`  and tag to latest. 
$ Set kubeconfig for sandbox
$ helm uninstall flyte -n flyte
$  helm install -n flyte -f values-sandbox.yaml --create-namespace flyte . 
```

Test On Local :
```
$ flytectl sandbox start
$ Clone & checkout the PR https://github.com/flyteorg/flyteadmin/pull/254
$ go run cmd/scheduler/main.go precheck --config flyteadmin_config.yaml 
$ kubectl port-forward deployment/flyteadmin 8080:8080 -n flyte 
$ add admin config in flyteadmin_config.yaml
$ go run cmd/scheduler/main.go precheck --config flyteadmin_config.yaml
```

Not tested with auth & SSL.(https://github.com/flyteorg/flyte/issues/1471)

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
