### PR TITLE
Added profiler configuration for scheduler and starting it

### DIFF
--- a/cmd/scheduler/entrypoints/scheduler.go
+++ b/cmd/scheduler/entrypoints/scheduler.go
@@ -61,7 +61,7 @@ var schedulerRunCmd = &cobra.Command{
 		// Serve profiling endpoints.
 		go func() {
 			err := profutils.StartProfilingServerWithDefaultHandlers(
-				ctx, schedulerConfiguration.ProfilerPort, nil)
+				ctx, schedulerConfiguration.ProfilerPort.Port, nil)
 			if err != nil {
 				logger.Panicf(ctx, "Failed to Start profiling and Metrics server. Error, %v", err)
 			}

--- a/cmd/scheduler/entrypoints/scheduler.go
+++ b/cmd/scheduler/entrypoints/scheduler.go
@@ -8,11 +8,12 @@ import (
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	repositoryCommonConfig "github.com/flyteorg/flyteadmin/pkg/repositories/config"
 	"github.com/flyteorg/flyteadmin/pkg/runtime"
-	scheduler "github.com/flyteorg/flyteadmin/scheduler"
+	"github.com/flyteorg/flyteadmin/scheduler"
 	schdulerRepoConfig "github.com/flyteorg/flyteadmin/scheduler/repositories"
 	"github.com/flyteorg/flyteidl/clients/go/admin"
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/logger"
+	"github.com/flyteorg/flytestdlib/profutils"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
 
@@ -27,6 +28,7 @@ var schedulerRunCmd = &cobra.Command{
 		ctx := context.Background()
 		configuration := runtime.NewConfigurationProvider()
 		applicationConfiguration := configuration.ApplicationConfiguration().GetTopLevelConfig()
+		schedulerConfiguration := configuration.ApplicationConfiguration().GetSchedulerConfig()
 
 		// Define the schedulerScope for prometheus metrics
 		schedulerScope := promutils.NewScope(applicationConfiguration.MetricsScope).NewSubScope("flytescheduler")
@@ -54,7 +56,16 @@ var schedulerRunCmd = &cobra.Command{
 		scheduleExecutor := scheduler.NewScheduledExecutor(db,
 			configuration.ApplicationConfiguration().GetSchedulerConfig().GetWorkflowExecutorConfig(), schedulerScope, adminServiceClient)
 
-		logger.Info(context.Background(), "Successfully initialized a native flyte scheduler")
+		logger.Info(ctx, "Successfully initialized a native flyte scheduler")
+
+		// Serve profiling endpoints.
+		go func() {
+			err := profutils.StartProfilingServerWithDefaultHandlers(
+				context.Background(), schedulerConfiguration.ProfilerPort, nil)
+			if err != nil {
+				logger.Panicf(ctx, "Failed to Start profiling and Metrics server. Error, %v", err)
+			}
+		}()
 
 		err = scheduleExecutor.Run(ctx)
 		if err != nil {

--- a/cmd/scheduler/entrypoints/scheduler.go
+++ b/cmd/scheduler/entrypoints/scheduler.go
@@ -61,7 +61,7 @@ var schedulerRunCmd = &cobra.Command{
 		// Serve profiling endpoints.
 		go func() {
 			err := profutils.StartProfilingServerWithDefaultHandlers(
-				context.Background(), schedulerConfiguration.ProfilerPort, nil)
+				ctx, schedulerConfiguration.ProfilerPort, nil)
 			if err != nil {
 				logger.Panicf(ctx, "Failed to Start profiling and Metrics server. Error, %v", err)
 			}

--- a/pkg/manager/impl/node_execution_manager.go
+++ b/pkg/manager/impl/node_execution_manager.go
@@ -438,7 +438,7 @@ func (m *NodeExecutionManager) GetNodeExecutionData(
 		return nil, err
 	}
 	signedInputsURLBlob := admin.UrlBlob{}
-	if nodeExecution.InputUri != "" {
+	if len(nodeExecution.InputUri) != 0 {
 		signedInputsURLBlob, err = m.urlData.Get(ctx, nodeExecution.InputUri)
 		if err != nil {
 			return nil, err

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -39,7 +39,7 @@ var flyteAdminConfig = config.MustRegisterSection(flyteAdmin, &interfaces.Applic
 	AsyncEventsBufferSize: 100,
 })
 var schedulerConfig = config.MustRegisterSection(scheduler, &interfaces.SchedulerConfig{
-	ProfilerPort: 10253,
+	ProfilerPort: config.Port{Port: 10253},
 	EventSchedulerConfig: interfaces.EventSchedulerConfig{
 		Scheme:               common.Local,
 		FlyteSchedulerConfig: &interfaces.FlyteSchedulerConfig{},

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -39,6 +39,7 @@ var flyteAdminConfig = config.MustRegisterSection(flyteAdmin, &interfaces.Applic
 	AsyncEventsBufferSize: 100,
 })
 var schedulerConfig = config.MustRegisterSection(scheduler, &interfaces.SchedulerConfig{
+	ProfilerPort: 10253,
 	EventSchedulerConfig: interfaces.EventSchedulerConfig{
 		Scheme:               common.Local,
 		FlyteSchedulerConfig: &interfaces.FlyteSchedulerConfig{},

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -232,6 +232,8 @@ func (f *AdminRateLimit) GetBurst() int {
 
 // This configuration is the base configuration for all scheduler-related set-up.
 type SchedulerConfig struct {
+	// Determines which port the profiling server used for scheduler monitoring and application debugging uses.
+	ProfilerPort           int                    `json:"profilerPort"`
 	EventSchedulerConfig   EventSchedulerConfig   `json:"eventScheduler"`
 	WorkflowExecutorConfig WorkflowExecutorConfig `json:"workflowExecutor"`
 	// Specifies the number of times to attempt recreating a workflow executor client should there be any disruptions.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -1,6 +1,9 @@
 package interfaces
 
-import "golang.org/x/time/rate"
+import (
+	"github.com/flyteorg/flytestdlib/config"
+	"golang.org/x/time/rate"
+)
 
 // This configuration section is used to for initiating the database connection with the store that holds registered
 // entities (e.g. workflows, tasks, launch plans...)
@@ -233,7 +236,7 @@ func (f *AdminRateLimit) GetBurst() int {
 // This configuration is the base configuration for all scheduler-related set-up.
 type SchedulerConfig struct {
 	// Determines which port the profiling server used for scheduler monitoring and application debugging uses.
-	ProfilerPort           int                    `json:"profilerPort"`
+	ProfilerPort           config.Port            `json:"profilerPort"`
 	EventSchedulerConfig   EventSchedulerConfig   `json:"eventScheduler"`
 	WorkflowExecutorConfig WorkflowExecutorConfig `json:"workflowExecutor"`
 	// Specifies the number of times to attempt recreating a workflow executor client should there be any disruptions.


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Defined new profile configuration for the scheduler and starting it during bootup in separate go routine.

Tested this locally by bringing up the scheduler and navigating to
http://localhost:10253/metrics

Sample data
```
# HELP flyte:flytescheduler:catchup_error_counter count of unsuccessful attempts to catchup on the schedules
# TYPE flyte:flytescheduler:catchup_error_counter counter
flyte:flytescheduler:catchup_error_counter 0
# HELP flyte:flytescheduler:checkpoint_creation_error_counter count of unsuccessful attempts to create the snapshot from the inmemory map
# TYPE flyte:flytescheduler:checkpoint_creation_error_counter counter
flyte:flytescheduler:checkpoint_creation_error_counter 0
# HELP flyte:flytescheduler:checkpoint_save_error_counter count of unsuccessful attempts to save the created snapshot to the DB
# TYPE flyte:flytescheduler:checkpoint_save_error_counter counter
flyte:flytescheduler:checkpoint_save_error_counter 0
# HELP flyte:flytescheduler:database:postgres:errors:already_exists counts for when a unique constraint was violated in a database operation
# TYPE flyte:flytescheduler:database:postgres:errors:already_exists counter
flyte:flytescheduler:database:postgres:errors:already_exists 0
# HELP flyte:flytescheduler:database:postgres:errors:gorm_error unspecified gorm error returned by database operation
# TYPE flyte:flytescheduler:database:postgres:errors:gorm_error counter
flyte:flytescheduler:database:postgres:errors:gorm_error 0
# HELP flyte:flytescheduler:database:postgres:errors:not_found count of all queries for entities not found in the database
# TYPE flyte:flytescheduler:database:postgres:errors:not_found counter
flyte:flytescheduler:database:postgres:errors:not_found 0
# HELP flyte:flytescheduler:database:postgres:errors:postgres_error unspecified postgres error returned in a database operation
# TYPE flyte:flytescheduler:database:postgres:errors:postgres_error counter
flyte:flytescheduler:database:postgres:errors:postgres_error 0
# HELP flyte:flytescheduler:database:postgres:errors:undefined_table database operations referencing an undefined table
# TYPE flyte:flytescheduler:database:postgres:errors:undefined_table counter
flyte:flytescheduler:database:postgres:errors:undefined_table 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms time taken to create a new entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:create_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms time taken to delete an individual entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:delete_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms time taken to determine whether an individual entry exists
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:exists_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms time taken to get an entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms{quantile="0.5"} 1
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms{quantile="0.9"} 2
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms{quantile="0.99"} 2
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms_sum 3
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:get_ms_count 2
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms time taken to list identifier entries
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_identifiers_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms time taken to list entries
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:list_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms time taken to update an entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms summary
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedulable_entity:update_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms time taken to create a new entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:create_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms time taken to delete an individual entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:delete_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms time taken to determine whether an individual entry exists
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:exists_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms time taken to get an entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms{quantile="0.5"} 3
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms{quantile="0.9"} 3
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms{quantile="0.99"} 3
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms_sum 3
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:get_ms_count 1
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms time taken to list identifier entries
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_identifiers_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms time taken to list entries
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:list_ms_count 0
# HELP flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms time taken to update an entry
# TYPE flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms summary
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms{quantile="0.5"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms{quantile="0.9"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms{quantile="0.99"} NaN
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms_sum 0
flyte:flytescheduler:database:postgres:repositories:schedule_entities_snapshot:update_ms_count 0
# HELP flyte:flytescheduler:failed_execution_counter count of unsuccessful attempts to fire execution for a schedules
# TYPE flyte:flytescheduler:failed_execution_counter counter
flyte:flytescheduler:failed_execution_counter 0
# HELP flyte:flytescheduler:job_func_panic_counter count of crashes for the job functions executed by the scheduler
# TYPE flyte:flytescheduler:job_func_panic_counter counter
flyte:flytescheduler:job_func_panic_counter 0
# HELP flyte:flytescheduler:job_schedule_failed_counter count of scheduling failures by the scheduler
# TYPE flyte:flytescheduler:job_schedule_failed_counter counter
flyte:flytescheduler:job_schedule_failed_counter 0
# HELP flyte:flytescheduler:successful_execution_counter count of successful attempts to fire execution for a schedules
# TYPE flyte:flytescheduler:successful_execution_counter counter
flyte:flytescheduler:successful_execution_counter 0
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.2508e-05
go_gc_duration_seconds{quantile="0.25"} 8.0925e-05
go_gc_duration_seconds{quantile="0.5"} 0.000105328
go_gc_duration_seconds{quantile="0.75"} 0.00014878
go_gc_duration_seconds{quantile="1"} 0.000353739
go_gc_duration_seconds_sum 0.00072128
go_gc_duration_seconds_count 5
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 21
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.16.6"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 6.02824e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.5578232e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.449455e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 76299
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 0.025576029250767702
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 5.31012e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 6.02824e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.8253312e+07
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 7.872512e+06
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 37702
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 5.7253888e+07
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 6.6125824e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.632209706715938e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 114001
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 19200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 32768
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 226712
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 245760
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 7.715088e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 2.744177e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 983040
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 983040
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 7.6891144e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 20
# HELP grpc_client_handled_total Total number of RPCs completed by the client, regardless of success or failure.
# TYPE grpc_client_handled_total counter
grpc_client_handled_total{grpc_code="Unavailable",grpc_method="GetOAuth2Metadata",grpc_service="flyteidl.service.AuthMetadataService",grpc_type="unary"} 1
# HELP grpc_client_msg_received_total Total number of RPC stream messages received by the client.
# TYPE grpc_client_msg_received_total counter
grpc_client_msg_received_total{grpc_method="GetOAuth2Metadata",grpc_service="flyteidl.service.AuthMetadataService",grpc_type="unary"} 1
# HELP grpc_client_msg_sent_total Total number of gRPC stream messages sent by the client.
# TYPE grpc_client_msg_sent_total counter
grpc_client_msg_sent_total{grpc_method="GetOAuth2Metadata",grpc_service="flyteidl.service.AuthMetadataService",grpc_type="unary"} 1
# HELP grpc_client_started_total Total number of RPCs started on the client.
# TYPE grpc_client_started_total counter
grpc_client_started_total{grpc_method="GetOAuth2Metadata",grpc_service="flyteidl.service.AuthMetadataService",grpc_type="unary"} 1
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```


## Type
 - [] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
