### PR TITLE
Added default admin config for MaxParallelism

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -537,7 +537,8 @@ func (m *ExecutionManager) getInheritedExecMetadata(ctx context.Context, request
 
 // Produces execution-time attributes for workflow execution.
 // Defaults to overridable execution values set in the execution create request, then looks at the launch plan values
-// (if any) before defaulting to values set in the matchable resource db.
+// (if any) before defaulting to values set in the matchable resource db and further if matchable resources don't
+// exist then defaults to one set in application configuration
 func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admin.ExecutionCreateRequest,
 	launchPlan *admin.LaunchPlan) (*admin.WorkflowExecutionConfig, error) {
 	if request.Spec.MaxParallelism > 0 {
@@ -565,7 +566,10 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 	if resource != nil && resource.Attributes.GetWorkflowExecutionConfig() != nil {
 		return resource.Attributes.GetWorkflowExecutionConfig(), nil
 	}
-	return nil, nil
+	// Defaults to one from the application config
+	return &admin.WorkflowExecutionConfig{
+		MaxParallelism: m.config.ApplicationConfiguration().GetTopLevelConfig().GetMaxParallelism(),
+	}, nil
 }
 
 func (m *ExecutionManager) launchSingleTaskExecution(

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -37,7 +37,9 @@ var flyteAdminConfig = config.MustRegisterSection(flyteAdmin, &interfaces.Applic
 	MetadataStoragePrefix: []string{"metadata", "admin"},
 	EventVersion:          1,
 	AsyncEventsBufferSize: 100,
+	MaxParallelism:        25,
 })
+
 var schedulerConfig = config.MustRegisterSection(scheduler, &interfaces.SchedulerConfig{
 	EventSchedulerConfig: interfaces.EventSchedulerConfig{
 		Scheme:               common.Local,

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -54,6 +54,38 @@ type ApplicationConfig struct {
 	EventVersion int `json:"eventVersion"`
 	// Specifies the shared buffer size which is used to queue asynchronous event writes.
 	AsyncEventsBufferSize int `json:"asyncEventsBufferSize"`
+	// Controls the maximum number of task nodes that can be run in parallel for the entire workflow.
+	// This is useful to achieve fairness. Note: MapTasks are regarded as one unit,
+	// and parallelism/concurrency of MapTasks is independent from this.
+	MaxParallelism int32 `json:"maxParallelism"`
+}
+
+func (a *ApplicationConfig) GetRoleNameKey() string {
+	return a.RoleNameKey
+}
+
+func (a *ApplicationConfig) GetMetricsScope() string {
+	return a.MetricsScope
+}
+
+func (a *ApplicationConfig) GetProfilerPort() int {
+	return a.ProfilerPort
+}
+
+func (a *ApplicationConfig) GetMetadataStoragePrefix() []string {
+	return a.MetadataStoragePrefix
+}
+
+func (a *ApplicationConfig) GetEventVersion() int {
+	return a.EventVersion
+}
+
+func (a *ApplicationConfig) GetAsyncEventsBufferSize() int {
+	return a.AsyncEventsBufferSize
+}
+
+func (a *ApplicationConfig) GetMaxParallelism() int32 {
+	return a.MaxParallelism
 }
 
 // This section holds common config for AWS


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR

Workflow executions can be gated by the max number of parallel nodes that can be processed. Specific override support for this MaxParallelism value already exists but not a generic default in the FlyteAdmin config.

This PR adds support in the admin config and provides a default value of 25 
Following is the order in which property override is checked

- launchplan spec override
- matchable resource attribute override
- admin application config override (defaults to 25 or else uses the configured value)


## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1532

## Follow-up issue
_NA_
