### PR TITLE
Prefer to set task limits from requests when only the latter is set

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -435,9 +435,6 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	if resource != nil && resource.Attributes != nil && resource.Attributes.GetTaskResourceAttributes() != nil {
 		taskResourceSpec = resource.Attributes.GetTaskResourceAttributes().Defaults
 	}
-	logger.Warnf(ctx, "setting task resources with defaults [%+v], task container [%+v], and taskResourceSpec [%+v]",
-		m.config.TaskResourceConfiguration().GetDefaults().CPU	,
-		task.Template.GetContainer().Resources.Requests, taskResourceSpec)
 	task.Template.GetContainer().Resources.Requests = assignResourcesIfUnset(
 		ctx, task.Template.Id, m.config.TaskResourceConfiguration().GetDefaults(), task.Template.GetContainer().Resources.Requests,
 		taskResourceSpec)
@@ -450,9 +447,7 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	task.Template.GetContainer().Resources.Limits = assignResourcesIfUnset(
 		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task, m.config.TaskResourceConfiguration().GetDefaults()), task.Template.GetContainer().Resources.Limits,
 		taskResourceSpec)
-	logger.Warnf(ctx, "computed task limits [%+v]", task.Template.GetContainer().Resources.Limits)
 	checkTaskRequestsLessThanLimits(ctx, task.Template.Id, task.Template.GetContainer().Resources)
-	logger.Warnf(ctx, "and adjusted requests downwards [%+v]", task.Template.Id, task.Template.GetContainer().Resources)
 }
 
 func fromAdminProtoTaskResourceSpec(ctx context.Context, spec *admin.TaskResourceSpec) runtimeInterfaces.TaskResourceSet {

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"strconv"
 	"time"
 
@@ -294,6 +295,7 @@ func assignResourcesIfUnset(ctx context.Context, identifier *core.Identifier,
 			ephemeralStorageindex = idx
 		}
 	}
+	logger.Warnf(ctx, "cpu index [%+v]", cpuIndex)
 	if cpuIndex > 0 && memoryIndex > 0 && ephemeralStorageindex > 0 {
 		// nothing to do
 		return resourceEntries
@@ -342,6 +344,7 @@ func assignResourcesIfUnset(ctx context.Context, identifier *core.Identifier,
 			resourceEntries = append(resourceEntries, ephemeralStorageResource)
 		}
 	}
+	logger.Warnf(ctx, "returning [%+v]", resourceEntries)
 	return resourceEntries
 }
 
@@ -387,6 +390,7 @@ func checkTaskRequestsLessThanLimits(ctx context.Context, identifier *core.Ident
 // itself => Limit := Min([Some-Multiplier X Request], System-Max). For now we are using a multiplier of 1. In
 // general we recommend the users to set limits close to requests for more predictability in the system.
 func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *core.CompiledTask, workflowName string) {
+	logger.Warnf(ctx, "setting compiled task defaults")
 	if task == nil {
 		logger.Warningf(ctx, "Can't set default resources for nil task.")
 		return
@@ -421,6 +425,9 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	if resource != nil && resource.Attributes != nil && resource.Attributes.GetTaskResourceAttributes() != nil {
 		taskResourceSpec = resource.Attributes.GetTaskResourceAttributes().Defaults
 	}
+	logger.Warnf(ctx, "setting task resources with defaults [%+v], task container [%+v], and taskResourceSpec [%+v]",
+		m.config.TaskResourceConfiguration().GetDefaults().CPU.String(),
+		task.Template.GetContainer().Resources.Requests, taskResourceSpec)
 	task.Template.GetContainer().Resources.Requests = assignResourcesIfUnset(
 		ctx, task.Template.Id, m.config.TaskResourceConfiguration().GetDefaults(), task.Template.GetContainer().Resources.Requests,
 		taskResourceSpec)

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -3,7 +3,6 @@ package impl
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"strconv"
 	"time"
 
@@ -426,7 +425,7 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 		taskResourceSpec = resource.Attributes.GetTaskResourceAttributes().Defaults
 	}
 	logger.Warnf(ctx, "setting task resources with defaults [%+v], task container [%+v], and taskResourceSpec [%+v]",
-		m.config.TaskResourceConfiguration().GetDefaults().CPU.String(),
+		m.config.TaskResourceConfiguration().GetDefaults().CPU	,
 		task.Template.GetContainer().Resources.Requests, taskResourceSpec)
 	task.Template.GetContainer().Resources.Requests = assignResourcesIfUnset(
 		ctx, task.Template.Id, m.config.TaskResourceConfiguration().GetDefaults(), task.Template.GetContainer().Resources.Requests,
@@ -440,7 +439,9 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	task.Template.GetContainer().Resources.Limits = assignResourcesIfUnset(
 		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task, m.config.TaskResourceConfiguration().GetDefaults()), task.Template.GetContainer().Resources.Limits,
 		taskResourceSpec)
+	logger.Warnf(ctx, "computed task limits [%+v]", task.Template.GetContainer().Resources.Limits)
 	checkTaskRequestsLessThanLimits(ctx, task.Template.Id, task.Template.GetContainer().Resources)
+	logger.Warnf(ctx, "and adjusted requests downwards [%+v]", task.Template.Id, task.Template.GetContainer().Resources)
 }
 
 func fromAdminProtoTaskResourceSpec(ctx context.Context, spec *admin.TaskResourceSpec) runtimeInterfaces.TaskResourceSet {

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3047,12 +3047,29 @@ func TestCreateTaskDefaultLimits(t *testing.T) {
 		assert.Equal(t, resource.MustParse("200Mi"), defaultLimits.Memory)
 		assert.Equal(t, resource.MustParse("200m"), defaultLimits.CPU)
 	})
-	t.Run("use_limits_from_config", func(t *testing.T) {
+	t.Run("use_limits_from_requests", func(t *testing.T) {
 		defaultLimits := createTaskDefaultLimits(context.Background(), task, resourceLimits)
-		assert.Equal(t, resource.MustParse("500Gi"), defaultLimits.Memory)
-		assert.Equal(t, resource.MustParse("300m"), defaultLimits.CPU)
+		assert.Equal(t, resource.MustParse("200Mi"), defaultLimits.Memory)
+		assert.Equal(t, resource.MustParse("200m"), defaultLimits.CPU)
 	})
 	t.Run("use_limits_from_config", func(t *testing.T) {
+		task := &core.CompiledTask{
+			Template: &core.TaskTemplate{
+				Target: &core.TaskTemplate_Container{
+					Container: &core.Container{
+						Resources: &core.Resources{
+							Requests: []*core.Resources_ResourceEntry{
+								{
+									Name:  core.Resources_MEMORY,
+									Value: "200Mi",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
 		limits := runtimeInterfaces.TaskResourceSet{
 			CPU: resource.MustParse("300m"),
 		}

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -28,7 +28,7 @@ func TestCreateProject(t *testing.T) {
 			ResourceType: core.ResourceType_TASK,
 		},
 	})
-	assert.EqualError(t, err, "rpc error: code = NotFound desc = missing entity of type TASK" +
+	assert.EqualError(t, err, "rpc error: code = NotFound desc = missing entity of type TASK"+
 		" with identifier project:\"potato\" domain:\"development\" name:\"task\" version:\"1234\" ")
 	assert.Empty(t, task)
 


### PR DESCRIPTION
# TL;DR
Users report that 

> we're noticing that setting resource requests, but not limits, for tasks is causing the requests to not be honored. it appears that the platform defaults are getting set for the limits, and copied into requests. is this intended?

The source of this is that an earlier change erroneously preferred to assign unset limits from the admin application config rather than set request values (when they were set).

Tested on flytesandbox

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1450

## Follow-up issue
_NA_
