### PR TITLE
Do not run  docker container as root #patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder /artifacts /bin
 # Ensure the latest CA certs are present to authenticate SSL connections.
 RUN apk --update add ca-certificates
 
-RUN groupadd -g 1000 flyte && useradd -r -u 1000 -g flyte flyte
+RUN addgroup -S flyte && adduser -S flyte -G flyte
 USER flyte
 
 CMD ["flyteadmin"]

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -32,7 +32,7 @@ COPY --from=builder /artifacts /bin
 # Ensure the latest CA certs are present to authenticate SSL connections.
 RUN apk --update add ca-certificates
 
-RUN groupadd -g 1000 flyte && useradd -r -u 1000 -g flyte flyte
+RUN addgroup -S flyte && adduser -S flyte -G flyte
 USER flyte
 
 CMD ["flytescheduler"]


### PR DESCRIPTION
# TL;DR
Fixes the Docker container not to run as root. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
The change is made in the Dockerfiles, where we create a new group and user to use for running the command. 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1606

## Follow-up issue
