### PR TITLE
Trim whitespace for password #patch

### DIFF
--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
@@ -97,7 +98,9 @@ func (p *ApplicationConfigurationProvider) GetDbConfig() interfaces.DbConfig {
 			logger.Fatalf(context.Background(), "failed to read database password from path [%s] with err: %v",
 				dbConfigSection.PasswordPath, err)
 		}
-		password = string(passwordVal)
+		// Passwords can contain special characters as long as they are percent encoded
+		// https://www.postgresql.org/docs/current/libpq-connect.html
+		password = strings.TrimSpace(string(passwordVal))
 	}
 	return interfaces.DbConfig{
 		Host:         dbConfigSection.Host,


### PR DESCRIPTION
Signed-off-by: stephen batifol <stephen.batifol@wolt.com>

# TL;DR
Same as https://github.com/flyteorg/datacatalog/pull/56

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Use the function TrimSpace that "returns a slice of the string s, with all leading and trailing white space removed, as defined by Unicode."
