### PR TITLE
Inline execution event data can be offloaded to cloud blobstore 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,63 @@ go 1.17
 
 require (
 	cloud.google.com/go v0.79.0
-	cloud.google.com/go/pubsub v1.10.1 // indirect
 	cloud.google.com/go/storage v1.14.0
+	github.com/NYTimes/gizmo v1.3.6
+	github.com/Selvatico/go-mocket v1.0.7
+	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/aws/aws-sdk-go v1.37.31
+	github.com/benbjohnson/clock v1.1.0
+	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/flyteorg/flyteidl v0.21.4
+	github.com/flyteorg/flyteplugins v0.7.0
+	github.com/flyteorg/flytepropeller v0.14.11
+	github.com/flyteorg/flytestdlib v0.3.36
+	github.com/ghodss/yaml v1.0.0
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.1.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/protobuf v1.4.3
+	github.com/google/uuid v1.2.0
+	github.com/googleapis/gax-go/v2 v2.0.5
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/securecookie v1.1.1
+	github.com/graymeta/stow v0.2.7
+	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69
+	github.com/jinzhu/gorm v1.9.16
+	github.com/lestrrat-go/jwx v1.1.6
+	github.com/lib/pq v1.10.0
+	github.com/magiconair/properties v1.8.4
+	github.com/mitchellh/mapstructure v1.4.1
+	github.com/ory/fosite v0.39.0
+	github.com/ory/x v0.0.162
+	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.9.0
+	github.com/prometheus/client_model v0.2.0
+	github.com/qor/validations v0.0.0-20171228122639-f364bca61b46
+	github.com/robfig/cron/v3 v3.0.0
+	github.com/sendgrid/sendgrid-go v3.10.0+incompatible
+	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
+	google.golang.org/api v0.42.0
+	google.golang.org/genproto v0.0.0-20210315173758-2651cd453018
+	google.golang.org/grpc v1.36.0
+	google.golang.org/protobuf v1.25.0
+	gopkg.in/gormigrate.v1 v1.6.0
+	k8s.io/api v0.20.4
+	k8s.io/apimachinery v0.20.4
+	k8s.io/client-go v0.20.2
+	sigs.k8s.io/controller-runtime v0.8.3
+)
+
+require (
+	cloud.google.com/go/pubsub v1.10.1 // indirect
 	github.com/Azure/azure-sdk-for-go v52.4.0+incompatible // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
@@ -13,60 +68,34 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/NYTimes/gizmo v1.3.6
-	github.com/Selvatico/go-mocket v1.0.7
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
-	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/aws/aws-sdk-go v1.37.31
-	github.com/benbjohnson/clock v1.1.0
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/coocood/freecache v1.1.1 // indirect
-	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
-	github.com/flyteorg/flyteidl v0.21.4
-	github.com/flyteorg/flyteplugins v0.7.0
-	github.com/flyteorg/flytepropeller v0.14.11
-	github.com/flyteorg/flytestdlib v0.3.36
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/goccy/go-json v0.4.8 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
-	github.com/gogo/protobuf v1.3.2
-	github.com/golang-jwt/jwt/v4 v4.1.0
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.2.0
-	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/googleapis/gnostic v0.5.4 // indirect
-	github.com/gorilla/handlers v1.5.1
-	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/graymeta/stow v0.2.7
-	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jinzhu/gorm v1.9.16
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -76,82 +105,56 @@ require (
 	github.com/lestrrat-go/backoff/v2 v2.0.7 // indirect
 	github.com/lestrrat-go/httpcc v1.0.0 // indirect
 	github.com/lestrrat-go/iter v1.0.1 // indirect
-	github.com/lestrrat-go/jwx v1.1.6
 	github.com/lestrrat-go/option v1.0.0 // indirect
-	github.com/lib/pq v1.10.0
-	github.com/magiconair/properties v1.8.4
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/goveralls v0.0.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/mitchellh/mapstructure v1.4.1
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/ncw/swift v1.0.53 // indirect
-	github.com/ory/fosite v0.39.0
 	github.com/ory/go-acc v0.2.5 // indirect
 	github.com/ory/go-convenience v0.1.0 // indirect
 	github.com/ory/viper v1.7.5 // indirect
-	github.com/ory/x v0.0.162
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
-	github.com/prometheus/client_golang v1.9.0
-	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.19.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/qor/qor v1.2.0 // indirect
-	github.com/qor/validations v0.0.0-20171228122639-f364bca61b46
-	github.com/robfig/cron/v3 v3.0.0
 	github.com/sendgrid/rest v2.6.4+incompatible // indirect
-	github.com/sendgrid/sendgrid-go v3.10.0+incompatible
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
-	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
-	github.com/stretchr/testify v1.7.0
 	github.com/subosito/gotenv v1.2.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.5 // indirect
-	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.1.2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/api v0.42.0
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20210315173758-2651cd453018
-	google.golang.org/grpc v1.36.0
 	google.golang.org/grpc/examples v0.0.0-20210315211313-1e7119b13689 // indirect
-	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
-	gopkg.in/gormigrate.v1 v1.6.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.20.4
-	k8s.io/apimachinery v0.20.4
-	k8s.io/client-go v0.20.2
 	k8s.io/klog/v2 v2.8.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1 // indirect
 	k8s.io/utils v0.0.0-20210305010621-2afb4311ab10 // indirect
-	sigs.k8s.io/controller-runtime v0.8.3
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,63 +4,8 @@ go 1.17
 
 require (
 	cloud.google.com/go v0.79.0
-	cloud.google.com/go/storage v1.14.0
-	github.com/NYTimes/gizmo v1.3.6
-	github.com/Selvatico/go-mocket v1.0.7
-	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/aws/aws-sdk-go v1.37.31
-	github.com/benbjohnson/clock v1.1.0
-	github.com/coreos/go-oidc v2.2.1+incompatible
-	github.com/evanphx/json-patch v4.9.0+incompatible
-	github.com/flyteorg/flyteidl v0.21.4
-	github.com/flyteorg/flyteplugins v0.7.0
-	github.com/flyteorg/flytepropeller v0.14.11
-	github.com/flyteorg/flytestdlib v0.3.36
-	github.com/ghodss/yaml v1.0.0
-	github.com/gogo/protobuf v1.3.2
-	github.com/golang-jwt/jwt/v4 v4.1.0
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/protobuf v1.4.3
-	github.com/google/uuid v1.2.0
-	github.com/googleapis/gax-go/v2 v2.0.5
-	github.com/gorilla/handlers v1.5.1
-	github.com/gorilla/securecookie v1.1.1
-	github.com/graymeta/stow v0.2.7
-	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69
-	github.com/jinzhu/gorm v1.9.16
-	github.com/lestrrat-go/jwx v1.1.6
-	github.com/lib/pq v1.10.0
-	github.com/magiconair/properties v1.8.4
-	github.com/mitchellh/mapstructure v1.4.1
-	github.com/ory/fosite v0.39.0
-	github.com/ory/x v0.0.162
-	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.9.0
-	github.com/prometheus/client_model v0.2.0
-	github.com/qor/validations v0.0.0-20171228122639-f364bca61b46
-	github.com/robfig/cron/v3 v3.0.0
-	github.com/sendgrid/sendgrid-go v3.10.0+incompatible
-	github.com/spf13/cobra v1.1.3
-	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.7.0
-	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
-	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
-	google.golang.org/api v0.42.0
-	google.golang.org/genproto v0.0.0-20210315173758-2651cd453018
-	google.golang.org/grpc v1.36.0
-	google.golang.org/protobuf v1.25.0
-	gopkg.in/gormigrate.v1 v1.6.0
-	k8s.io/api v0.20.4
-	k8s.io/apimachinery v0.20.4
-	k8s.io/client-go v0.20.2
-	sigs.k8s.io/controller-runtime v0.8.3
-)
-
-require (
 	cloud.google.com/go/pubsub v1.10.1 // indirect
+	cloud.google.com/go/storage v1.14.0
 	github.com/Azure/azure-sdk-for-go v52.4.0+incompatible // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
@@ -68,34 +13,60 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/NYTimes/gizmo v1.3.6
+	github.com/Selvatico/go-mocket v1.0.7
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/aws/aws-sdk-go v1.37.31
+	github.com/benbjohnson/clock v1.1.0
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/coocood/freecache v1.1.1 // indirect
+	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/flyteorg/flyteidl v0.21.4
+	github.com/flyteorg/flyteplugins v0.7.0
+	github.com/flyteorg/flytepropeller v0.14.11
+	github.com/flyteorg/flytestdlib v0.3.36
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/goccy/go-json v0.4.8 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.1.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.2.0
+	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/googleapis/gnostic v0.5.4 // indirect
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/graymeta/stow v0.2.7
+	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jinzhu/gorm v1.9.16
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -105,56 +76,82 @@ require (
 	github.com/lestrrat-go/backoff/v2 v2.0.7 // indirect
 	github.com/lestrrat-go/httpcc v1.0.0 // indirect
 	github.com/lestrrat-go/iter v1.0.1 // indirect
+	github.com/lestrrat-go/jwx v1.1.6
 	github.com/lestrrat-go/option v1.0.0 // indirect
+	github.com/lib/pq v1.10.0
+	github.com/magiconair/properties v1.8.4
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/goveralls v0.0.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/ncw/swift v1.0.53 // indirect
+	github.com/ory/fosite v0.39.0
 	github.com/ory/go-acc v0.2.5 // indirect
 	github.com/ory/go-convenience v0.1.0 // indirect
 	github.com/ory/viper v1.7.5 // indirect
+	github.com/ory/x v0.0.162
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
+	github.com/prometheus/client_golang v1.9.0
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.19.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/qor/qor v1.2.0 // indirect
+	github.com/qor/validations v0.0.0-20171228122639-f364bca61b46
+	github.com/robfig/cron/v3 v3.0.0
 	github.com/sendgrid/rest v2.6.4+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.10.0+incompatible
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/subosito/gotenv v1.2.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.1.2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.42.0
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210315173758-2651cd453018
+	google.golang.org/grpc v1.36.0
 	google.golang.org/grpc/examples v0.0.0-20210315211313-1e7119b13689 // indirect
+	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
+	gopkg.in/gormigrate.v1 v1.6.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.20.4
+	k8s.io/apimachinery v0.20.4
+	k8s.io/client-go v0.20.2
 	k8s.io/klog/v2 v2.8.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1 // indirect
 	k8s.io/utils v0.0.0-20210305010621-2afb4311ab10 // indirect
+	sigs.k8s.io/controller-runtime v0.8.3
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/pkg/common/data_store.go
+++ b/pkg/common/data_store.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"context"
+
+	"github.com/flyteorg/flyteadmin/pkg/errors"
+	"github.com/flyteorg/flyteadmin/pkg/manager/impl/shared"
+	"google.golang.org/grpc/codes"
+
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flytestdlib/storage"
+)
+
+func OffloadLiteralMap(ctx context.Context, storageClient *storage.DataStore, literalMap *core.LiteralMap, nestedKeys ...string) (storage.DataReference, error) {
+	if literalMap == nil {
+		literalMap = &core.LiteralMap{}
+	}
+	nestedKeyReference := []string{
+		shared.Metadata,
+	}
+	nestedKeyReference = append(nestedKeyReference, nestedKeys...)
+	uri, err := storageClient.ConstructReference(ctx, storageClient.GetBaseContainerFQN(ctx), nestedKeyReference...)
+	if err != nil {
+		return "", errors.NewFlyteAdminErrorf(codes.Internal, "Failed to construct data reference for [%+v] with err: %v", nestedKeys, err)
+	}
+	if err := storageClient.WriteProtobuf(ctx, uri, storage.Options{}, literalMap); err != nil {
+		return "", errors.NewFlyteAdminErrorf(codes.Internal, "Failed to write protobuf for [%+v] with err: %v", nestedKeys, err)
+	}
+	return uri, nil
+}

--- a/pkg/common/data_store_test.go
+++ b/pkg/common/data_store_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/flyteorg/flyteadmin/pkg/errors"
+	"google.golang.org/grpc/codes"
+
 	commonMocks "github.com/flyteorg/flyteadmin/pkg/common/mocks"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/storage"
@@ -39,4 +42,24 @@ func TestOffloadLiteralMap(t *testing.T) {
 	uri, err := OffloadLiteralMap(context.TODO(), mockStorage, literalMap, "nested", "key")
 	assert.NoError(t, err)
 	assert.Equal(t, "s3://bucket/metadata/nested/key", uri.String())
+}
+
+func TestOffloadLiteralMap_ConstructReferenceError(t *testing.T) {
+	mockStorage := commonMocks.GetMockStorageClient()
+	mockStorage.ComposedProtobufStore.(*commonMocks.TestDataStore).ConstructReferenceCb = func(
+		ctx context.Context, reference storage.DataReference, nestedKeys ...string) (storage.DataReference, error) {
+		return "foo", errors.NewFlyteAdminError(codes.Internal, "foo")
+	}
+	_, err := OffloadLiteralMap(context.TODO(), mockStorage, literalMap, "nested", "key")
+	assert.Equal(t, err.(errors.FlyteAdminError).Code(), codes.Internal)
+}
+
+func TestOffloadLiteralMap_StorageFailure(t *testing.T) {
+	mockStorage := commonMocks.GetMockStorageClient()
+	mockStorage.ComposedProtobufStore.(*commonMocks.TestDataStore).WriteProtobufCb = func(ctx context.Context, reference storage.DataReference, opts storage.Options, msg proto.Message) error {
+		assert.Equal(t, reference.String(), "s3://bucket/metadata/nested/key")
+		return errors.NewFlyteAdminError(codes.Internal, "foo")
+	}
+	_, err := OffloadLiteralMap(context.TODO(), mockStorage, literalMap, "nested", "key")
+	assert.Equal(t, err.(errors.FlyteAdminError).Code(), codes.Internal)
 }

--- a/pkg/common/data_store_test.go
+++ b/pkg/common/data_store_test.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	commonMocks "github.com/flyteorg/flyteadmin/pkg/common/mocks"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flytestdlib/storage"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+var literalMap = &core.LiteralMap{
+	Literals: map[string]*core.Literal{
+		"foo": {
+			Value: &core.Literal_Scalar{
+				Scalar: &core.Scalar{
+					Value: &core.Scalar_Primitive{
+						Primitive: &core.Primitive{
+							Value: &core.Primitive_Integer{
+								Integer: 4,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestOffloadLiteralMap(t *testing.T) {
+	mockStorage := commonMocks.GetMockStorageClient()
+	mockStorage.ComposedProtobufStore.(*commonMocks.TestDataStore).WriteProtobufCb = func(ctx context.Context, reference storage.DataReference, opts storage.Options, msg proto.Message) error {
+		assert.Equal(t, reference.String(), "s3://bucket/metadata/nested/key")
+		return nil
+	}
+
+	uri, err := OffloadLiteralMap(context.TODO(), mockStorage, literalMap, "nested", "key")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3://bucket/metadata/nested/key", uri.String())
+}

--- a/pkg/manager/impl/node_execution_manager.go
+++ b/pkg/manager/impl/node_execution_manager.go
@@ -123,11 +123,13 @@ func (m *NodeExecutionManager) createNodeExecutionWithEvent(
 		}
 		parentID = &parentNodeExecutionModel.ID
 	}
-	nodeExecutionModel, err := transformers.CreateNodeExecutionModel(transformers.ToNodeExecutionModelInput{
+	nodeExecutionModel, err := transformers.CreateNodeExecutionModel(ctx, transformers.ToNodeExecutionModelInput{
 		Request:                      request,
 		ParentTaskExecutionID:        parentTaskExecutionID,
 		ParentID:                     parentID,
 		DynamicWorkflowRemoteClosure: dynamicWorkflowRemoteClosureReference,
+		InlineEventDataPolicy:        m.config.ApplicationConfiguration().GetRemoteDataConfig().InlineEventDataPolicy,
+		StorageClient:                m.storageClient,
 	})
 	if err != nil {
 		logger.Debugf(ctx, "failed to create node execution model for event request: %s with err: %v",
@@ -175,7 +177,9 @@ func (m *NodeExecutionManager) updateNodeExecutionWithEvent(
 			return updateFailed, err
 		}
 	}
-	err := transformers.UpdateNodeExecutionModel(request, nodeExecutionModel, childExecutionID, dynamicWorkflowRemoteClosureReference)
+	err := transformers.UpdateNodeExecutionModel(ctx, request, nodeExecutionModel, childExecutionID,
+		dynamicWorkflowRemoteClosureReference, m.config.ApplicationConfiguration().GetRemoteDataConfig().InlineEventDataPolicy,
+		m.storageClient)
 	if err != nil {
 		logger.Debugf(ctx, "failed to update node execution model: %+v with err: %v", request.Event.Id, err)
 		return updateFailed, err

--- a/pkg/manager/impl/task_execution_manager.go
+++ b/pkg/manager/impl/task_execution_manager.go
@@ -81,8 +81,11 @@ func (m *TaskExecutionManager) createTaskExecution(
 	}
 
 	taskExecutionModel, err := transformers.CreateTaskExecutionModel(
+		ctx,
 		transformers.CreateTaskExecutionModelInput{
-			Request: request,
+			Request:               request,
+			InlineEventDataPolicy: m.config.ApplicationConfiguration().GetRemoteDataConfig().InlineEventDataPolicy,
+			StorageClient:         m.storageClient,
 		})
 	if err != nil {
 		logger.Debugf(ctx, "failed to transform task execution %+v into database model: %v", request.Event.TaskId, err)
@@ -104,7 +107,8 @@ func (m *TaskExecutionManager) updateTaskExecutionModelState(
 	ctx context.Context, request *admin.TaskExecutionEventRequest, existingTaskExecution *models.TaskExecution) (
 	models.TaskExecution, error) {
 
-	err := transformers.UpdateTaskExecutionModel(request, existingTaskExecution)
+	err := transformers.UpdateTaskExecutionModel(ctx, request, existingTaskExecution,
+		m.config.ApplicationConfiguration().GetRemoteDataConfig().InlineEventDataPolicy, m.storageClient)
 	if err != nil {
 		logger.Debugf(ctx, "failed to update task execution model [%+v] with err: %v", request.Event.TaskId, err)
 		return models.TaskExecution{}, err

--- a/pkg/repositories/transformers/constants.go
+++ b/pkg/repositories/transformers/constants.go
@@ -1,0 +1,3 @@
+package transformers
+
+const Outputs = "offloaded_outputs"

--- a/pkg/repositories/transformers/constants.go
+++ b/pkg/repositories/transformers/constants.go
@@ -1,3 +1,5 @@
 package transformers
 
-const Outputs = "offloaded_outputs"
+// OutputsObjectSuffix is used when execution event data includes inline outputs but the admin deployment is configured
+// to offload such data. The generated file path for the offloaded data will include the execution identifier and this suffix.
+const OutputsObjectSuffix = "offloaded_outputs"

--- a/pkg/repositories/transformers/execution.go
+++ b/pkg/repositories/transformers/execution.go
@@ -155,7 +155,7 @@ func UpdateExecutionModelState(
 		default:
 			logger.Debugf(ctx, "Offloading outputs per InlineEventDataPolicy")
 			uri, err := common.OffloadLiteralMap(ctx, storageClient, request.Event.GetOutputData(),
-				request.Event.ExecutionId.Project, request.Event.ExecutionId.Domain, request.Event.ExecutionId.Name, Outputs)
+				request.Event.ExecutionId.Project, request.Event.ExecutionId.Domain, request.Event.ExecutionId.Name, OutputsObjectSuffix)
 			if err != nil {
 				return err
 			}

--- a/pkg/repositories/transformers/execution.go
+++ b/pkg/repositories/transformers/execution.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
+
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -104,7 +106,9 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 
 // Updates an existing model given a WorkflowExecution event.
 func UpdateExecutionModelState(
-	execution *models.Execution, request admin.WorkflowExecutionEventRequest) error {
+	ctx context.Context,
+	execution *models.Execution, request admin.WorkflowExecutionEventRequest,
+	inlineEventDataPolicy interfaces.InlineEventDataPolicy, storageClient *storage.DataStore) error {
 	var executionClosure admin.ExecutionClosure
 	err := proto.Unmarshal(execution.Closure, &executionClosure)
 	if err != nil {
@@ -143,8 +147,25 @@ func UpdateExecutionModelState(
 			},
 		}
 	} else if request.Event.GetOutputData() != nil {
-		executionClosure.OutputResult = &admin.ExecutionClosure_OutputData{
-			OutputData: request.Event.GetOutputData(),
+		switch inlineEventDataPolicy {
+		case interfaces.InlineEventDataPolicyStoreInline:
+			executionClosure.OutputResult = &admin.ExecutionClosure_OutputData{
+				OutputData: request.Event.GetOutputData(),
+			}
+		default:
+			logger.Debugf(ctx, "Offloading outputs per InlineEventDataPolicy")
+			uri, err := common.OffloadLiteralMap(ctx, storageClient, request.Event.GetOutputData(),
+				request.Event.ExecutionId.Project, request.Event.ExecutionId.Domain, request.Event.ExecutionId.Name, Outputs)
+			if err != nil {
+				return err
+			}
+			executionClosure.OutputResult = &admin.ExecutionClosure_Outputs{
+				Outputs: &admin.LiteralMapBlob{
+					Data: &admin.LiteralMapBlob_Uri{
+						Uri: uri.String(),
+					},
+				},
+			}
 		}
 	} else if request.Event.GetError() != nil {
 		executionClosure.OutputResult = &admin.ExecutionClosure_Error{

--- a/pkg/repositories/transformers/node_execution.go
+++ b/pkg/repositories/transformers/node_execution.go
@@ -79,7 +79,7 @@ func addTerminalState(
 			logger.Debugf(ctx, "Offloading outputs per InlineEventDataPolicy")
 			uri, err := common.OffloadLiteralMap(ctx, storageClient, request.Event.GetOutputData(),
 				request.Event.Id.ExecutionId.Project, request.Event.Id.ExecutionId.Domain, request.Event.Id.ExecutionId.Name,
-				request.Event.Id.NodeId, Outputs)
+				request.Event.Id.NodeId, OutputsObjectSuffix)
 			if err != nil {
 				return err
 			}

--- a/pkg/repositories/transformers/node_execution.go
+++ b/pkg/repositories/transformers/node_execution.go
@@ -3,6 +3,9 @@ package transformers
 import (
 	"context"
 
+	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
+	"github.com/flyteorg/flytestdlib/storage"
+
 	"github.com/flyteorg/flytestdlib/logger"
 
 	"github.com/flyteorg/flyteadmin/pkg/common"
@@ -24,6 +27,8 @@ type ToNodeExecutionModelInput struct {
 	ParentTaskExecutionID        uint
 	ParentID                     *uint
 	DynamicWorkflowRemoteClosure string
+	InlineEventDataPolicy        interfaces.InlineEventDataPolicy
+	StorageClient                *storage.DataStore
 }
 
 func addNodeRunningState(request *admin.NodeExecutionEventRequest, nodeExecutionModel *models.NodeExecution,
@@ -44,8 +49,9 @@ func addNodeRunningState(request *admin.NodeExecutionEventRequest, nodeExecution
 }
 
 func addTerminalState(
+	ctx context.Context,
 	request *admin.NodeExecutionEventRequest, nodeExecutionModel *models.NodeExecution,
-	closure *admin.NodeExecutionClosure) error {
+	closure *admin.NodeExecutionClosure, inlineEventDataPolicy interfaces.InlineEventDataPolicy, storageClient *storage.DataStore) error {
 	if closure.StartedAt == nil {
 		logger.Warning(context.Background(), "node execution is missing StartedAt")
 	} else {
@@ -64,8 +70,22 @@ func addTerminalState(
 			OutputUri: request.Event.GetOutputUri(),
 		}
 	} else if request.Event.GetOutputData() != nil {
-		closure.OutputResult = &admin.NodeExecutionClosure_OutputData{
-			OutputData: request.Event.GetOutputData(),
+		switch inlineEventDataPolicy {
+		case interfaces.InlineEventDataPolicyStoreInline:
+			closure.OutputResult = &admin.NodeExecutionClosure_OutputData{
+				OutputData: request.Event.GetOutputData(),
+			}
+		default:
+			logger.Debugf(ctx, "Offloading outputs per InlineEventDataPolicy")
+			uri, err := common.OffloadLiteralMap(ctx, storageClient, request.Event.GetOutputData(),
+				request.Event.Id.ExecutionId.Project, request.Event.Id.ExecutionId.Domain, request.Event.Id.ExecutionId.Name,
+				request.Event.Id.NodeId, Outputs)
+			if err != nil {
+				return err
+			}
+			closure.OutputResult = &admin.NodeExecutionClosure_OutputUri{
+				OutputUri: uri.String(),
+			}
 		}
 	} else if request.Event.GetError() != nil {
 		closure.OutputResult = &admin.NodeExecutionClosure_Error{
@@ -78,7 +98,7 @@ func addTerminalState(
 	return nil
 }
 
-func CreateNodeExecutionModel(input ToNodeExecutionModelInput) (*models.NodeExecution, error) {
+func CreateNodeExecutionModel(ctx context.Context, input ToNodeExecutionModelInput) (*models.NodeExecution, error) {
 	nodeExecution := &models.NodeExecution{
 		NodeExecutionKey: models.NodeExecutionKey{
 			NodeID: input.Request.Event.Id.NodeId,
@@ -110,7 +130,7 @@ func CreateNodeExecutionModel(input ToNodeExecutionModelInput) (*models.NodeExec
 		}
 	}
 	if common.IsNodeExecutionTerminal(input.Request.Event.Phase) {
-		err := addTerminalState(input.Request, nodeExecution, &closure)
+		err := addTerminalState(ctx, input.Request, nodeExecution, &closure, input.InlineEventDataPolicy, input.StorageClient)
 		if err != nil {
 			return nil, err
 		}
@@ -142,8 +162,9 @@ func CreateNodeExecutionModel(input ToNodeExecutionModelInput) (*models.NodeExec
 }
 
 func UpdateNodeExecutionModel(
-	request *admin.NodeExecutionEventRequest, nodeExecutionModel *models.NodeExecution,
-	targetExecution *core.WorkflowExecutionIdentifier, dynamicWorkflowRemoteClosure string) error {
+	ctx context.Context, request *admin.NodeExecutionEventRequest, nodeExecutionModel *models.NodeExecution,
+	targetExecution *core.WorkflowExecutionIdentifier, dynamicWorkflowRemoteClosure string,
+	inlineEventDataPolicy interfaces.InlineEventDataPolicy, storageClient *storage.DataStore) error {
 	var nodeExecutionClosure admin.NodeExecutionClosure
 	err := proto.Unmarshal(nodeExecutionModel.Closure, &nodeExecutionClosure)
 	if err != nil {
@@ -161,7 +182,7 @@ func UpdateNodeExecutionModel(
 		}
 	}
 	if common.IsNodeExecutionTerminal(request.Event.Phase) {
-		err := addTerminalState(request, nodeExecutionModel, &nodeExecutionClosure)
+		err := addTerminalState(ctx, request, nodeExecutionModel, &nodeExecutionClosure, inlineEventDataPolicy, storageClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -81,7 +81,7 @@ func addTaskTerminalState(
 				request.Event.ParentNodeExecutionId.ExecutionId.Project, request.Event.ParentNodeExecutionId.ExecutionId.Domain,
 				request.Event.ParentNodeExecutionId.ExecutionId.Name, request.Event.ParentNodeExecutionId.NodeId,
 				request.Event.TaskId.Project, request.Event.TaskId.Domain, request.Event.TaskId.Name, request.Event.TaskId.Version,
-				strconv.FormatUint(uint64(request.Event.RetryAttempt), 10), Outputs)
+				strconv.FormatUint(uint64(request.Event.RetryAttempt), 10), OutputsObjectSuffix)
 			if err != nil {
 				return err
 			}

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -2,6 +2,10 @@ package transformers
 
 import (
 	"context"
+	"strconv"
+
+	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
+	"github.com/flyteorg/flytestdlib/storage"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -23,7 +27,9 @@ var empty _struct.Struct
 var jsonEmpty, _ = protojson.Marshal(&empty)
 
 type CreateTaskExecutionModelInput struct {
-	Request *admin.TaskExecutionEventRequest
+	Request               *admin.TaskExecutionEventRequest
+	InlineEventDataPolicy interfaces.InlineEventDataPolicy
+	StorageClient         *storage.DataStore
 }
 
 func addTaskStartedState(request *admin.TaskExecutionEventRequest, taskExecutionModel *models.TaskExecution,
@@ -38,8 +44,10 @@ func addTaskStartedState(request *admin.TaskExecutionEventRequest, taskExecution
 }
 
 func addTaskTerminalState(
+	ctx context.Context,
 	request *admin.TaskExecutionEventRequest,
-	taskExecutionModel *models.TaskExecution, closure *admin.TaskExecutionClosure) error {
+	taskExecutionModel *models.TaskExecution, closure *admin.TaskExecutionClosure,
+	inlineEventDataPolicy interfaces.InlineEventDataPolicy, storageClient *storage.DataStore) error {
 	if taskExecutionModel.StartedAt == nil {
 		logger.Warning(context.Background(), "task execution is missing StartedAt")
 	} else {
@@ -62,8 +70,24 @@ func addTaskTerminalState(
 			OutputUri: request.Event.GetOutputUri(),
 		}
 	} else if request.Event.GetOutputData() != nil {
-		closure.OutputResult = &admin.TaskExecutionClosure_OutputData{
-			OutputData: request.Event.GetOutputData(),
+		switch inlineEventDataPolicy {
+		case interfaces.InlineEventDataPolicyStoreInline:
+			closure.OutputResult = &admin.TaskExecutionClosure_OutputData{
+				OutputData: request.Event.GetOutputData(),
+			}
+		default:
+			logger.Debugf(ctx, "Offloading outputs per InlineEventDataPolicy")
+			uri, err := common.OffloadLiteralMap(ctx, storageClient, request.Event.GetOutputData(),
+				request.Event.ParentNodeExecutionId.ExecutionId.Project, request.Event.ParentNodeExecutionId.ExecutionId.Domain,
+				request.Event.ParentNodeExecutionId.ExecutionId.Name, request.Event.ParentNodeExecutionId.NodeId,
+				request.Event.TaskId.Project, request.Event.TaskId.Domain, request.Event.TaskId.Name, request.Event.TaskId.Version,
+				strconv.FormatUint(uint64(request.Event.RetryAttempt), 10), Outputs)
+			if err != nil {
+				return err
+			}
+			closure.OutputResult = &admin.TaskExecutionClosure_OutputUri{
+				OutputUri: uri.String(),
+			}
 		}
 	} else if request.Event.GetError() != nil {
 		closure.OutputResult = &admin.TaskExecutionClosure_Error{
@@ -73,7 +97,7 @@ func addTaskTerminalState(
 	return nil
 }
 
-func CreateTaskExecutionModel(input CreateTaskExecutionModelInput) (*models.TaskExecution, error) {
+func CreateTaskExecutionModel(ctx context.Context, input CreateTaskExecutionModelInput) (*models.TaskExecution, error) {
 	taskExecution := &models.TaskExecution{
 		TaskExecutionKey: models.TaskExecutionKey{
 			TaskKey: models.TaskKey{
@@ -121,7 +145,7 @@ func CreateTaskExecutionModel(input CreateTaskExecutionModelInput) (*models.Task
 	}
 
 	if common.IsTaskExecutionTerminal(input.Request.Event.Phase) {
-		err := addTaskTerminalState(input.Request, taskExecution, closure)
+		err := addTaskTerminalState(ctx, input.Request, taskExecution, closure, input.InlineEventDataPolicy, input.StorageClient)
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +240,8 @@ func mergeCustom(existing, latest *_struct.Struct) (*_struct.Struct, error) {
 	return &response, nil
 }
 
-func UpdateTaskExecutionModel(request *admin.TaskExecutionEventRequest, taskExecutionModel *models.TaskExecution) error {
+func UpdateTaskExecutionModel(ctx context.Context, request *admin.TaskExecutionEventRequest, taskExecutionModel *models.TaskExecution,
+	inlineEventDataPolicy interfaces.InlineEventDataPolicy, storageClient *storage.DataStore) error {
 	var taskExecutionClosure admin.TaskExecutionClosure
 	err := proto.Unmarshal(taskExecutionModel.Closure, &taskExecutionClosure)
 	if err != nil {
@@ -240,7 +265,7 @@ func UpdateTaskExecutionModel(request *admin.TaskExecutionEventRequest, taskExec
 	}
 
 	if common.IsTaskExecutionTerminal(request.Event.Phase) {
-		err := addTaskTerminalState(request, taskExecutionModel, &taskExecutionClosure)
+		err := addTaskTerminalState(ctx, request, taskExecutionModel, &taskExecutionClosure, inlineEventDataPolicy, storageClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -57,8 +57,9 @@ var schedulerConfig = config.MustRegisterSection(scheduler, &interfaces.Schedule
 	},
 })
 var remoteDataConfig = config.MustRegisterSection(remoteData, &interfaces.RemoteDataConfig{
-	Scheme:         common.None,
-	MaxSizeInBytes: 2 * MB,
+	Scheme:                common.None,
+	MaxSizeInBytes:        2 * MB,
+	InlineEventDataPolicy: interfaces.InlineEventDataPolicyOffload,
 })
 var notificationsConfig = config.MustRegisterSection(notifications, &interfaces.NotificationsConfig{
 	Type: common.Local,

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -301,15 +301,16 @@ type SignedURL struct {
 	SigningPrincipal string `json:"signingPrincipal"`
 }
 
-type InlineEventDataPolicy = string
+//go:generate enumer -type=InlineEventDataPolicy -trimprefix=InlineEventDataPolicy
+type InlineEventDataPolicy = int
 
 const (
 	// InlineEventDataPolicyOffload specifies that inline execution event data (e.g. outputs) should be offloaded to the
 	// configured cloud blob store.
-	InlineEventDataPolicyOffload = "offload"
+	InlineEventDataPolicyOffload InlineEventDataPolicy = iota
 	// InlineEventDataPolicyStoreInline specifies that inline execution event data should be saved inline with execution
 	// database entries.
-	InlineEventDataPolicyStoreInline = "inline"
+	InlineEventDataPolicyStoreInline
 )
 
 // This configuration handles all requests to get and write remote data such as execution inputs & outputs.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -323,7 +323,7 @@ type RemoteDataConfig struct {
 	// Specifies the max size in bytes for which execution data such as inputs and outputs will be populated in line.
 	MaxSizeInBytes int64 `json:"maxSizeInBytes"`
 	// Specifies how inline execution event data should be saved in the backend
-	InlineEventDataPolicy InlineEventDataPolicy `json:"inlineEventDataPolicy"`
+	InlineEventDataPolicy InlineEventDataPolicy `json:"inlineEventDataPolicy" pflag:",Specifies how inline execution event data should be saved in the backend"`
 }
 
 // This section handles configuration for the workflow notifications pipeline.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -301,7 +301,18 @@ type SignedURL struct {
 	SigningPrincipal string `json:"signingPrincipal"`
 }
 
-// This configuration handles all requests to get remote data such as execution inputs & outputs.
+type InlineEventDataPolicy = string
+
+const (
+	// InlineEventDataPolicyOffload specifies that inline execution event data (e.g. outputs) should be offloaded to the
+	// configured cloud blob store.
+	InlineEventDataPolicyOffload = "offload"
+	// InlineEventDataPolicyStoreInline specifies that inline execution event data should be saved inline with execution
+	// database entries.
+	InlineEventDataPolicyStoreInline = "inline"
+)
+
+// This configuration handles all requests to get and write remote data such as execution inputs & outputs.
 type RemoteDataConfig struct {
 	// Defines the cloud provider that backs the scheduler. In the absence of a specification the no-op, 'local'
 	// scheme is used.
@@ -311,6 +322,8 @@ type RemoteDataConfig struct {
 	SignedURL SignedURL `json:"signedUrls"`
 	// Specifies the max size in bytes for which execution data such as inputs and outputs will be populated in line.
 	MaxSizeInBytes int64 `json:"maxSizeInBytes"`
+	// Specifies how inline execution event data should be saved in the backend
+	InlineEventDataPolicy InlineEventDataPolicy `json:"inlineEventDataPolicy"`
 }
 
 // This section handles configuration for the workflow notifications pipeline.


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Inline event data can now configured to be offloaded rather than saved in the flyteadmin db.
In the future we can explore an async write approach for this code path.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1789

## Follow-up issue
_NA_
