### PR TITLE
Allow tokens with multiple audiences as long as one matches

### DIFF
--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -133,11 +133,15 @@ func (p Provider) ValidateAccessToken(ctx context.Context, expectedAudience, tok
 
 func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}) (interfaces.IdentityContext, error) {
 	claims := jwtx.ParseMapStringInterfaceClaims(claimsRaw)
-	if len(claims.Audience) != 1 {
-		return nil, fmt.Errorf("expected exactly one granted audience. found [%v]", len(claims.Audience))
+
+	foundAud := false
+	for _, aud := range claims.Audience {
+		if expectedAudience.Has(aud) {
+			foundAud = true
+		}
 	}
 
-	if !expectedAudience.Has(claims.Audience[0]) {
+	if !foundAud {
 		return nil, fmt.Errorf("invalid audience [%v]", claims.Audience[0])
 	}
 

--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -142,7 +142,7 @@ func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}
 	}
 
 	if !foundAud {
-		return nil, fmt.Errorf("invalid audience [%v]", claims.Audience[0])
+		return nil, fmt.Errorf("invalid audience [%v]", claims)
 	}
 
 	userInfo := &service.UserInfoResponse{}

--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -134,14 +134,15 @@ func (p Provider) ValidateAccessToken(ctx context.Context, expectedAudience, tok
 func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}) (interfaces.IdentityContext, error) {
 	claims := jwtx.ParseMapStringInterfaceClaims(claimsRaw)
 
-	foundAud := false
-	for _, aud := range claims.Audience {
+	foundAudIndex := -1
+	for audIndex, aud := range claims.Audience {
 		if expectedAudience.Has(aud) {
-			foundAud = true
+			foundAudIndex = audIndex
+			break
 		}
 	}
 
-	if !foundAud {
+	if foundAudIndex < 0 {
 		return nil, fmt.Errorf("invalid audience [%v]", claims)
 	}
 
@@ -174,7 +175,7 @@ func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}
 		scopes.Insert(auth.ScopeAll)
 	}
 
-	return auth.NewIdentityContext(claims.Audience[0], claims.Subject, clientID, claims.IssuedAt, scopes, userInfo), nil
+	return auth.NewIdentityContext(claims.Audience[foundAudIndex], claims.Subject, clientID, claims.IssuedAt, scopes, userInfo), nil
 }
 
 // NewProvider creates a new OAuth2 Provider that is able to do OAuth 2-legged and 3-legged flows. It'll lookup

--- a/auth/authzserver/provider_test.go
+++ b/auth/authzserver/provider_test.go
@@ -236,4 +236,35 @@ func Test_verifyClaims(t *testing.T) {
 		assert.Equal(t, "my-client", identityCtx.AppID())
 		assert.Equal(t, "123", identityCtx.UserID())
 	})
+
+	t.Run("Multiple audience", func(t *testing.T) {
+		_, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver"},
+				"user_info": map[string]interface{}{
+					"preferred_name": "John Doe",
+				},
+				"sub":       "123",
+				"client_id": "my-client",
+				"scp":       []interface{}{"all", "offline"},
+			})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("No matching audience", func(t *testing.T) {
+		_, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver3"},
+				"user_info": map[string]interface{}{
+					"preferred_name": "John Doe",
+				},
+				"sub":       "123",
+				"client_id": "my-client",
+				"scp":       []interface{}{"all", "offline"},
+			})
+
+		assert.Error(t, err)
+	})
+
 }

--- a/auth/interfaces/context.go
+++ b/auth/interfaces/context.go
@@ -59,6 +59,7 @@ type AuthenticationContext interface {
 // to the platform.
 type IdentityContext interface {
 	UserID() string
+	Audience() string
 	AppID() string
 	UserInfo() *service.UserInfoResponse
 	AuthenticatedAt() time.Time

--- a/auth/interfaces/mocks/identity_context.go
+++ b/auth/interfaces/mocks/identity_context.go
@@ -51,6 +51,38 @@ func (_m *IdentityContext) AppID() string {
 	return r0
 }
 
+type IdentityContext_Audience struct {
+	*mock.Call
+}
+
+func (_m IdentityContext_Audience) Return(_a0 string) *IdentityContext_Audience {
+	return &IdentityContext_Audience{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *IdentityContext) OnAudience() *IdentityContext_Audience {
+	c := _m.On("Audience")
+	return &IdentityContext_Audience{Call: c}
+}
+
+func (_m *IdentityContext) OnAudienceMatch(matchers ...interface{}) *IdentityContext_Audience {
+	c := _m.On("Audience", matchers...)
+	return &IdentityContext_Audience{Call: c}
+}
+
+// Audience provides a mock function with given fields:
+func (_m *IdentityContext) Audience() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 type IdentityContext_AuthenticatedAt struct {
 	*mock.Call
 }


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR

Tested this using keycloak as an external auth server.
The token generated by keycloak come with account as audience and verified that with admin not configured with this audience rejects the token

```
{"json":{"src":"handlers.go:237"},"level":"info","msg":"Failed to parse Access Token from context. Will attempt to find IDToken. Error: invalid audience [account]","ts":"2022-02-02T15:43:42+05:30"}
```

Unit tests added for multiple audience.

Tried adding keycloak token mapper to generate multiple audience but couldn't get that to work . But this code works in all cases which are required for this ticket.


## Type
 - [X] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1809