### PR TITLE
Align Flyte's label validation with kubernetes labels specification

### DIFF
--- a/pkg/manager/impl/launch_plan_manager_test.go
+++ b/pkg/manager/impl/launch_plan_manager_test.go
@@ -251,7 +251,7 @@ func TestLaunchPlanManager_CreateLaunchPlanErrorDueToBadLabels(t *testing.T) {
 			"bar": "baz",
 		}}
 	response, err := lpManager.CreateLaunchPlan(context.Background(), request)
-	assert.EqualError(t, err, "invalid label value [#badlabel]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]")
+	assert.EqualError(t, err, "invalid label value [#badlabel]: [a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]")
 	assert.Nil(t, response)
 }
 

--- a/pkg/manager/impl/project_manager_test.go
+++ b/pkg/manager/impl/project_manager_test.go
@@ -194,7 +194,7 @@ func TestProjectManager_CreateProjectErrorDueToBadLabels(t *testing.T) {
 			},
 		},
 	})
-	assert.EqualError(t, err, "invalid label value [#badlabel]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]")
+	assert.EqualError(t, err, "invalid label value [#badlabel]: [a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]")
 }
 
 func TestProjectManager_UpdateProject(t *testing.T) {

--- a/pkg/manager/impl/validation/launch_plan_validator_test.go
+++ b/pkg/manager/impl/validation/launch_plan_validator_test.go
@@ -48,7 +48,7 @@ func TestValidateLpLabels(t *testing.T) {
 			"bar": "baz",
 		}}
 	err := ValidateLaunchPlan(context.Background(), request, testutils.GetRepoWithDefaultProject(), lpApplicationConfig, getWorkflowInterface())
-	assert.EqualError(t, err, "invalid label value [#badlabel]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]")
+	assert.EqualError(t, err, "invalid label value [#badlabel]: [a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]")
 }
 
 func TestValidateLpEmptyVersion(t *testing.T) {

--- a/pkg/manager/impl/validation/project_validator_test.go
+++ b/pkg/manager/impl/validation/project_validator_test.go
@@ -117,7 +117,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "invalid label key [#badkey]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+			expectedError: "invalid label key [#badkey]: [name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]",
 		},
 		{
 			request: admin.ProjectRegisterRequest{
@@ -132,7 +132,7 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "invalid label value [.bad-label-value]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+			expectedError: "invalid label value [.bad-label-value]: [a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]",
 		},
 	}
 
@@ -150,7 +150,8 @@ func TestValidateProject_ValidProject(t *testing.T) {
 		State:       admin.Project_ARCHIVED,
 		Labels: &admin.Labels{
 			Values: map[string]string{
-				"foo": "bar",
+				"foo":                "bar",
+				"example.com/my-key": "my-value",
 			},
 		},
 	}))
@@ -234,7 +235,7 @@ func TestValidateProject(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "invalid label key [#badkey]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+			expectedError: "invalid label key [#badkey]: [name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]",
 		},
 	}
 

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -62,10 +62,10 @@ func validateLabels(labels *admin.Labels) error {
 // i.e. alphanumeric + - and _
 func validateLabelsAlphanumeric(labels *admin.Labels) error {
 	for key, value := range labels.Values {
-		if errs := validation.IsDNS1123Label(key); len(errs) > 0 {
+		if errs := validation.IsQualifiedName(key); len(errs) > 0 {
 			return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid label key [%s]: %v", key, errs)
 		}
-		if errs := validation.IsDNS1123Label(value); len(errs) > 0 {
+		if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
 			return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid label value [%s]: %v", value, errs)
 		}
 	}

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package tests
@@ -223,5 +224,5 @@ func TestUpdateProjectLabels_BadLabels(t *testing.T) {
 	})
 
 	// Assert that update went through without an error.
-	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = invalid label value [#bar]: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]")
+	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = invalid label value [#bar]: [a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]")
 }


### PR DESCRIPTION
# TL;DR
Make sure that Flyte's label validation has same implementation as kubernetes label validation.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Make sure that Flyte's label validation has same implementation as kubernetes label validation.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/1833

## Follow-up issue
_NA_
