### PR TITLE
Add /auth handler to validate requests and comply with nginx auth_res…

### DIFF
--- a/auth/authzserver/metadata_provider.go
+++ b/auth/authzserver/metadata_provider.go
@@ -18,7 +18,7 @@ type OAuth2MetadataProvider struct {
 	cfg *authConfig.Config
 }
 
-// Override auth func to enforce anonymous access on the implemented APIs
+// AuthFuncOverride overrides auth func to enforce anonymous access on the implemented APIs
 // Ref: https://github.com/grpc-ecosystem/go-grpc-middleware/blob/master/auth/auth.go#L31
 func (s OAuth2MetadataProvider) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
 	return ctx, nil

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -53,6 +53,7 @@ func RegisterHandlers(ctx context.Context, handler interfaces.HandlerRegisterer,
 // is present, it'll return 202 Accepted response. Otherwise, it'll return 401 Unauthorized response.
 func GetAuthVerifierHandler(ctx context.Context, authCtx interfaces.AuthenticationContext) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
+		logger.Debugf(ctx, "Request headers: %+v", request.Header)
 		_, err := IdentityContextFromRequest(ctx, request, authCtx)
 		if err != nil {
 			logger.Debugf(ctx, "Request unauthenticated. Error: %v", err)

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -53,7 +53,10 @@ func RegisterHandlers(ctx context.Context, handler interfaces.HandlerRegisterer,
 // is present, it'll return 202 Accepted response. Otherwise, it'll return 401 Unauthorized response.
 func GetAuthVerifierHandler(ctx context.Context, authCtx interfaces.AuthenticationContext) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		logger.Debugf(ctx, "Request headers: %+v", request.Header)
+		if logger.IsLoggable(ctx, logger.DebugLevel) {
+			logger.Debugf(ctx, "Request headers: %+v", request.Header)
+		}
+
 		_, err := IdentityContextFromRequest(ctx, request, authCtx)
 		if err != nil {
 			logger.Debugf(ctx, "Request unauthenticated. Error: %v", err)

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -62,6 +62,19 @@ func addCsrfCookie(request *http.Request) {
 	request.AddCookie(&cookie)
 }
 
+func TestGetAuthVerifierHandler(t *testing.T) {
+	ctx := context.Background()
+	localServer := httptest.NewServer(http.HandlerFunc(hf))
+	defer localServer.Close()
+	http.DefaultClient = localServer.Client()
+	mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
+	hf := GetAuthVerifierHandler(ctx, mockAuthCtx)
+	request := httptest.NewRequest("GET", localServer.URL+"/auth", nil)
+	writer := httptest.NewRecorder()
+	hf(writer, request)
+	assert.Equal(t, "403 Forbidden", writer.Result().Status)
+}
+
 func TestGetCallbackHandlerWithErrorOnToken(t *testing.T) {
 	ctx := context.Background()
 	hf := func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
…ponse protocol

Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Implements `/auth` endpoint in flyte admin that can respond with 401, 403 or 202 depending on whether the request 

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1898