### PR TITLE
Added default metric port in flytescheduler

### DIFF
--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -22,7 +22,7 @@ const remoteData = "remoteData"
 const notifications = "notifications"
 const domains = "domains"
 const externalEvents = "externalEvents"
-
+const metricPort = 10254
 const postgres = "postgres"
 
 const KB = 1024
@@ -36,7 +36,7 @@ var databaseConfig = config.MustRegisterSection(database, &interfaces.DbConfigSe
 	ExtraOptions: "sslmode=disable",
 })
 var flyteAdminConfig = config.MustRegisterSection(flyteAdmin, &interfaces.ApplicationConfig{
-	ProfilerPort:          10254,
+	ProfilerPort:          metricPort,
 	MetricsScope:          "flyte:",
 	MetadataStoragePrefix: []string{"metadata", "admin"},
 	EventVersion:          2,
@@ -45,7 +45,7 @@ var flyteAdminConfig = config.MustRegisterSection(flyteAdmin, &interfaces.Applic
 })
 
 var schedulerConfig = config.MustRegisterSection(scheduler, &interfaces.SchedulerConfig{
-	ProfilerPort: config.Port{Port: 10253},
+	ProfilerPort: config.Port{Port: metricPort},
 	EventSchedulerConfig: interfaces.EventSchedulerConfig{
 		Scheme:               common.Local,
 		FlyteSchedulerConfig: &interfaces.FlyteSchedulerConfig{},


### PR DESCRIPTION
# TL;DR
Currently flytescheduler use 10253 as default metric port, But all other component use 10254 as default,

Replace port 10253 -> 10254 in flytescheduler for metric

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1864

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
