### PR TITLE
Removed retries during precheck and falling back on k8s retries

### DIFF
--- a/cmd/scheduler/entrypoints/precheck.go
+++ b/cmd/scheduler/entrypoints/precheck.go
@@ -4,18 +4,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flyteadmin/pkg/runtime"
 	"github.com/flyteorg/flyteidl/clients/go/admin"
 	"github.com/flyteorg/flytestdlib/logger"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"k8s.io/client-go/util/retry"
 )
 
 const (
 	healthCheckSuccess = "Health check passed, Flyteadmin is up and running"
-	healthCheckError   = "Health check failed with status %v"
+	healthCheckError   = "health check failed with status %v"
 )
 
 var preCheckRunCmd = &cobra.Command{
@@ -24,40 +22,23 @@ var preCheckRunCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		appConfig := runtime.NewApplicationConfigurationProvider()
-		opts := appConfig.GetSchedulerConfig().GetPrecheckBackoff()
-
-		err := retry.OnError(opts,
-			func(err error) bool {
-				logger.Errorf(ctx, "Attempt failed due to %v", err)
-				return err != nil
-			},
-			func() error {
-				clientSet, err := admin.ClientSetBuilder().WithConfig(admin.GetConfig(ctx)).Build(ctx)
-
-				if err != nil {
-					logger.Errorf(ctx, "Flyte native scheduler precheck failed due to %v\n", err)
-					return err
-				}
-
-				healthCheckResponse, err := clientSet.HealthServiceClient().Check(ctx,
-					&grpc_health_v1.HealthCheckRequest{Service: "flyteadmin"})
-				if err != nil {
-					return err
-				}
-				if healthCheckResponse.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
-					logger.Errorf(ctx, healthCheckError, healthCheckResponse.GetStatus())
-					return fmt.Errorf(healthCheckError, healthCheckResponse.GetStatus())
-				}
-				logger.Infof(ctx, "Health check response is %v", healthCheckResponse)
-				return nil
-			},
-		)
+		clientSet, err := admin.ClientSetBuilder().WithConfig(admin.GetConfig(ctx)).Build(ctx)
 
 		if err != nil {
+			logger.Errorf(ctx, "Flyte native scheduler precheck failed due to %v\n", err)
 			return err
 		}
 
+		healthCheckResponse, err := clientSet.HealthServiceClient().Check(ctx,
+			&grpc_health_v1.HealthCheckRequest{Service: "flyteadmin"})
+		if err != nil {
+			return err
+		}
+		if healthCheckResponse.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+			logger.Errorf(ctx, healthCheckError, healthCheckResponse.GetStatus())
+			return fmt.Errorf(healthCheckError, healthCheckResponse.GetStatus())
+		}
+		logger.Infof(ctx, "Health check response is %v", healthCheckResponse)
 		logger.Infof(ctx, healthCheckSuccess)
 		return nil
 	},

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -2,17 +2,13 @@ package runtime
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
-	"strings"
-	"time"
-
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
 	"github.com/flyteorg/flytestdlib/config"
 	"github.com/flyteorg/flytestdlib/logger"
-
-	"k8s.io/apimachinery/pkg/util/wait"
+	"io/ioutil"
+	"os"
+	"strings"
 )
 
 const database = "database"
@@ -58,9 +54,6 @@ var schedulerConfig = config.MustRegisterSection(scheduler, &interfaces.Schedule
 				Burst: 10,
 			},
 		},
-	},
-	PrecheckBackoff: wait.Backoff{
-		Duration: time.Second, Factor: 2.0, Steps: 30, Jitter: 0.1,
 	},
 })
 var remoteDataConfig = config.MustRegisterSection(remoteData, &interfaces.RemoteDataConfig{

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -2,13 +2,14 @@ package runtime
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
 	"github.com/flyteorg/flytestdlib/config"
 	"github.com/flyteorg/flytestdlib/logger"
-	"io/ioutil"
-	"os"
-	"strings"
 )
 
 const database = "database"

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -3,7 +3,6 @@ package interfaces
 import (
 	"github.com/flyteorg/flytestdlib/config"
 	"golang.org/x/time/rate"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // This configuration section is used to for initiating the database connection with the store that holds registered
@@ -276,8 +275,6 @@ type SchedulerConfig struct {
 	ReconnectAttempts int `json:"reconnectAttempts"`
 	// Specifies the time interval to wait before attempting to reconnect the workflow executor client.
 	ReconnectDelaySeconds int `json:"reconnectDelaySeconds"`
-	// Specifies the backoff settings when scheduler checks for the flyteadmin health during startup.
-	PrecheckBackoff wait.Backoff `json:"backoff"`
 }
 
 func (s *SchedulerConfig) GetEventSchedulerConfig() EventSchedulerConfig {
@@ -294,10 +291,6 @@ func (s *SchedulerConfig) GetReconnectAttempts() int {
 
 func (s *SchedulerConfig) GetReconnectDelaySeconds() int {
 	return s.ReconnectDelaySeconds
-}
-
-func (s *SchedulerConfig) GetPrecheckBackoff() wait.Backoff {
-	return s.PrecheckBackoff
 }
 
 // Configuration specific to setting up signed urls.


### PR DESCRIPTION

# TL;DR
Removing the customized retries during scheduler precheck to determine admin health

In auth enabled admin, the scheduler precheck would initialize the admin client once and if in the first call to the authmetadata service is not up, then the TokenSource wont be setup and hence all calls to admin fail from the scheduler on all retries.

This is due to the fact that initialization of admin client is wrapped in Once.Do and which disallows multiple calls to same function as its purpose is to run just once. 

Even in case of panic or fatal error eg where authmetadat service is not yet up,   Once.Do(f) considers the function call to have returned which causes subsequent retries to be noop

```
// If f panics, Do considers it to have returned; future calls of Do return
// without calling f.
```

The only way to reset and have Once.Do make another call to the same function is by having another instance of Once which might be possible to do using Reset functionality where we replace the instance of Once.

https://github.com/flyteorg/flyteidl/blob/989fe6e4f51eed3a5a68b8f563244bd38b765f4c/clients/go/admin/client.go#L173
https://github.com/flyteorg/flyteidl/blob/989fe6e4f51eed3a5a68b8f563244bd38b765f4c/clients/go/admin/client.go#L28

But instead of doing that a simpler approach would be to rely on K8s retries.

### Testing done:
#### Until admin is up k8s retries the precheck init container which throws following error until admin is up

```
kubectl logs -f flytescheduler-6449fbdccb-6q9mg  -n flyte flytescheduler-check
time="2021-12-10T13:16:14Z" level=info msg="Using config file: [/etc/flyte/config/admin.yaml /etc/flyte/config/db.yaml /etc/flyte/config/logger.yaml]"
{"json":{"src":"client.go:181"},"level":"error","msg":"failed to initialize token source provider. Err: failed to fetch auth metadata. Error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.110.127.57:81: connect: connection refused\"","ts":"2021-12-10T13:16:15Z"}
{"json":{"src":"client.go:186"},"level":"warning","msg":"Starting an unauthenticated client because: can't create authenticated channel without a TokenSourceProvider","ts":"2021-12-10T13:16:15Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-12-10T13:16:15Z"}
Error: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.110.127.57:81: connect: connection refused"
Usage:
  flytescheduler precheck [flags]
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.110.127.57:81: connect: connection refused"

Flags:
  -h, --help   help for precheck

Global Flags:
      --admin.authorizationHeader string           Custom metadata header to pass JWT
      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
      --admin.clientId string                      Client ID (default "flytepropeller")
      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
      --admin.command strings                      Command for external authentication token generation
      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
      --admin.insecure                             Use insecure connection.
      --admin.insecureSkipVerify                   InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name. Caution : shouldn't be use for production usecases'
      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
      --admin.maxRetries int                       Max number of gRPC retries (default 4)
      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
      --admin.pkceConfig.refreshTime string         (default "5m0s")
      --admin.pkceConfig.timeout string             (default "15s")
      --admin.scopes strings                       List of scopes to request
      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
      --config string                              config file (default is ./flyteadmin_config.yaml)
      --logger.formatter.type string               Sets logging format type. (default "json")
      --logger.level int                           Sets the minimum logging level. (default 4)
      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
      --logger.show-source                         Includes source code location in logs.
      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
      --storage.connection.endpoint string         URL for storage client to connect to.
      --storage.connection.region string           Region to connect to. (default "us-east-1")
      --storage.connection.secret-key string       Secret to use when accesskey is set.
      --storage.container string                   Initial container (in s3 a bucket) to create -if it doesn't exist-.'
      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
      --storage.stow.config stringToString         Configuration for stow backend. Refer to github/graymeta/stow (default [])
      --storage.stow.kind string                   Kind of Stow backend to use. Refer to github/graymeta/stow
      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")

panic: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.110.127.57:81: connect: connection refused"

goroutine 1 [running]:
main.main()
	/go/src/github.com/flyteorg/flyteadmin/cmd/scheduler/main.go:12 +0xc5
```

#### When admin is up the checks pass
```
kubectl logs -f flytescheduler-6449fbdccb-6q9mg  -n flyte flytescheduler-check
time="2021-12-10T13:16:39Z" level=info msg="Using config file: [/etc/flyte/config/admin.yaml /etc/flyte/config/db.yaml /etc/flyte/config/logger.yaml]"
{"json":{"src":"client.go:181"},"level":"error","msg":"failed to initialize token source provider. Err: failed to fetch auth metadata. Error: rpc error: code = Unimplemented desc = unknown service flyteidl.service.AuthMetadataService","ts":"2021-12-10T13:16:39Z"}
{"json":{"src":"client.go:186"},"level":"warning","msg":"Starting an unauthenticated client because: can't create authenticated channel without a TokenSourceProvider","ts":"2021-12-10T13:16:39Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-12-10T13:16:39Z"}
{"json":{"src":"precheck.go:41"},"level":"info","msg":"Health check response is status:SERVING","ts":"2021-12-10T13:16:39Z"}
{"json":{"src":"precheck.go:42"},"level":"info","msg":"Health check passed, Flyteadmin is up and running","ts":"2021-12-10T13:16:39Z"}
```

#### Describe o/p of the init container which show restart counts 

```
Init Containers:
  flytescheduler-check:
    Container ID:  docker://835c02e8d184f750999bd5ae8431108bb85aa3227fb96df74192c2cb626d6a68
    Image:         docker.io/library/flytescheduler:76be847
    Image ID:      docker://sha256:f6642318126606764d976e6e2b0ba646139aea53ede792a1009bd7079c8a861b
    Port:          <none>
    Host Port:     <none>
    Command:
      flytescheduler
      precheck
      --config
      /etc/flyte/config/*.yaml
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 10 Dec 2021 18:46:39 +0530
      Finished:     Fri, 10 Dec 2021 18:46:39 +0530
    Ready:          True
    Restart Count:  3
    Environment:    <none>
    Mounts:
      /etc/flyte/config from config-volume (rw)
      /etc/secrets/ from auth (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from flytescheduler-token-6zlj7 (ro)
```

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Relies on K8s retries to precheck if admin pod is up instead of customized retries

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/1919

## Follow-up issue
_NA_

