### PR TITLE
Set task started_at on INITIALIZING to RUNNING phase transition

### DIFF
--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -257,7 +257,7 @@ func UpdateTaskExecutionModel(ctx context.Context, request *admin.TaskExecutionE
 	if len(request.Event.Reason) > 0 {
 		taskExecutionClosure.Reason = request.Event.Reason
 	}
-	if (existingTaskPhase == core.TaskExecution_QUEUED.String() || existingTaskPhase == core.TaskExecution_UNDEFINED.String()) && taskExecutionModel.Phase == core.TaskExecution_RUNNING.String() {
+	if (existingTaskPhase == core.TaskExecution_QUEUED.String() || existingTaskPhase == core.TaskExecution_INITIALIZING.String() || existingTaskPhase == core.TaskExecution_UNDEFINED.String()) && taskExecutionModel.Phase == core.TaskExecution_RUNNING.String() {
 		err = addTaskStartedState(request, taskExecutionModel, &taskExecutionClosure)
 		if err != nil {
 			return err

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -257,7 +257,7 @@ func UpdateTaskExecutionModel(ctx context.Context, request *admin.TaskExecutionE
 	if len(request.Event.Reason) > 0 {
 		taskExecutionClosure.Reason = request.Event.Reason
 	}
-	if (existingTaskPhase == core.TaskExecution_QUEUED.String() || existingTaskPhase == core.TaskExecution_INITIALIZING.String() || existingTaskPhase == core.TaskExecution_UNDEFINED.String()) && taskExecutionModel.Phase == core.TaskExecution_RUNNING.String() {
+	if existingTaskPhase != core.TaskExecution_RUNNING.String() && taskExecutionModel.Phase == core.TaskExecution_RUNNING.String() {
 		err = addTaskStartedState(request, taskExecutionModel, &taskExecutionClosure)
 		if err != nil {
 			return err


### PR DESCRIPTION
# TL;DR
Currently the "started_at" field is set on task execution on phase transition from QUEUED or UNDEFINED to RUNNING. FlytePropeller may sometimes send an event for the INITIALIZING phase, which is reported from the k8s watch API indicating the pod is in fact initializing. This PR enables setting the started_at field on transitions from INITIALIZING to RUNNING. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1945

## Follow-up issue
_NA_