### PR TITLE
Use empty target id for in-cluster

### DIFF
--- a/pkg/executioncluster/impl/in_cluster.go
+++ b/pkg/executioncluster/impl/in_cluster.go
@@ -14,8 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const defaultInClusterTargetID = "id"
-
 type InCluster struct {
 	target    executioncluster.ExecutionTarget
 	asTargets map[string]*executioncluster.ExecutionTarget
@@ -54,7 +52,6 @@ func NewInCluster(initializationErrorCounter prometheus.Counter, kubeConfig, mas
 		return nil, err
 	}
 	target := executioncluster.ExecutionTarget{
-		ID:            defaultInClusterTargetID,
 		Client:        kubeClient,
 		FlyteClient:   flyteClient,
 		DynamicClient: dynamicClient,

--- a/pkg/executioncluster/impl/in_cluster.go
+++ b/pkg/executioncluster/impl/in_cluster.go
@@ -14,13 +14,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// DO NOT USE: only for backwards compatiblity
+const defaultInClusterTargetID = "id"
+
 type InCluster struct {
 	target    executioncluster.ExecutionTarget
 	asTargets map[string]*executioncluster.ExecutionTarget
 }
 
 func (i InCluster) GetTarget(ctx context.Context, spec *executioncluster.ExecutionTargetSpec) (*executioncluster.ExecutionTarget, error) {
-	if spec != nil && spec.TargetID != "" {
+	if spec != nil && !(spec.TargetID == "" || spec.TargetID == defaultInClusterTargetID){
 		return nil, errors.New(fmt.Sprintf("remote target %s is not supported", spec.TargetID))
 	}
 	return &i.target, nil

--- a/pkg/executioncluster/impl/in_cluster.go
+++ b/pkg/executioncluster/impl/in_cluster.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// DO NOT USE: only for backwards compatiblity
+// DO NOT USE: only for backwards compatibility
 const defaultInClusterTargetID = "id"
 
 type InCluster struct {

--- a/pkg/executioncluster/impl/in_cluster.go
+++ b/pkg/executioncluster/impl/in_cluster.go
@@ -23,7 +23,7 @@ type InCluster struct {
 }
 
 func (i InCluster) GetTarget(ctx context.Context, spec *executioncluster.ExecutionTargetSpec) (*executioncluster.ExecutionTarget, error) {
-	if spec != nil && !(spec.TargetID == "" || spec.TargetID == defaultInClusterTargetID){
+	if spec != nil && !(spec.TargetID == "" || spec.TargetID == defaultInClusterTargetID) {
 		return nil, errors.New(fmt.Sprintf("remote target %s is not supported", spec.TargetID))
 	}
 	return &i.target, nil

--- a/pkg/executioncluster/impl/in_cluster_test.go
+++ b/pkg/executioncluster/impl/in_cluster_test.go
@@ -20,6 +20,15 @@ func TestInClusterGetTarget(t *testing.T) {
 	assert.Equal(t, "t1", target.ID)
 }
 
+func TestInClusterGetTarget_NoID(t *testing.T) {
+	cluster := InCluster{
+		target: executioncluster.ExecutionTarget{},
+	}
+	target, err := cluster.GetTarget(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.Empty(t, target.ID)
+}
+
 func TestInClusterGetRemoteTarget(t *testing.T) {
 	cluster := InCluster{
 		target: executioncluster.ExecutionTarget{},

--- a/pkg/executioncluster/impl/in_cluster_test.go
+++ b/pkg/executioncluster/impl/in_cluster_test.go
@@ -29,20 +29,18 @@ func TestInClusterGetRemoteTarget(t *testing.T) {
 }
 
 func TestInClusterGetAllValidTargets(t *testing.T) {
-	target := executioncluster.ExecutionTarget{
-		ID: defaultInClusterTargetID,
-	}
+	target := executioncluster.ExecutionTarget{}
 	cluster := InCluster{
 		target: target,
 		asTargets: map[string]*executioncluster.ExecutionTarget{
-			defaultInClusterTargetID: &target,
+			target.ID: &target,
 		},
 	}
 	targets := cluster.GetValidTargets()
 	assert.Equal(t, 1, len(targets))
-	assert.Equal(t, defaultInClusterTargetID, targets[defaultInClusterTargetID].ID)
+	assert.Empty(t, targets[target.ID].ID)
 
 	targets = cluster.GetAllTargets()
 	assert.Equal(t, 1, len(targets))
-	assert.Equal(t, defaultInClusterTargetID, targets[defaultInClusterTargetID].ID)
+	assert.Empty(t, targets[target.ID].ID)
 }

--- a/pkg/executioncluster/impl/in_cluster_test.go
+++ b/pkg/executioncluster/impl/in_cluster_test.go
@@ -26,17 +26,17 @@ func TestInClusterGetTarget_AllowableSpecIDs(t *testing.T) {
 	}
 	target, err := cluster.GetTarget(context.Background(), nil)
 	assert.Nil(t, err)
-	assert.Empty(t, target.ID)
+	assert.Equal(t, *target, cluster.target)
 
 	target, err = cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{})
 	assert.Nil(t, err)
-	assert.Empty(t, target.ID)
+	assert.Equal(t, *target, cluster.target)
 
 	target, err = cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
 		TargetID: defaultInClusterTargetID,
 	})
 	assert.Nil(t, err)
-	assert.Empty(t, target.ID)
+	assert.Equal(t, *target, cluster.target)
 
 	_, err = cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
 		TargetID: "t1",

--- a/pkg/executioncluster/impl/in_cluster_test.go
+++ b/pkg/executioncluster/impl/in_cluster_test.go
@@ -20,13 +20,28 @@ func TestInClusterGetTarget(t *testing.T) {
 	assert.Equal(t, "t1", target.ID)
 }
 
-func TestInClusterGetTarget_NoID(t *testing.T) {
+func TestInClusterGetTarget_AllowableSpecIDs(t *testing.T) {
 	cluster := InCluster{
 		target: executioncluster.ExecutionTarget{},
 	}
 	target, err := cluster.GetTarget(context.Background(), nil)
 	assert.Nil(t, err)
 	assert.Empty(t, target.ID)
+
+	target, err = cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{})
+	assert.Nil(t, err)
+	assert.Empty(t, target.ID)
+
+	target, err = cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
+		TargetID: defaultInClusterTargetID,
+	})
+	assert.Nil(t, err)
+	assert.Empty(t, target.ID)
+
+	_, err = cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
+		TargetID: "t1",
+	})
+	assert.Error(t, err)
 }
 
 func TestInClusterGetRemoteTarget(t *testing.T) {

--- a/pkg/executioncluster/impl/in_cluster_test.go
+++ b/pkg/executioncluster/impl/in_cluster_test.go
@@ -53,18 +53,20 @@ func TestInClusterGetRemoteTarget(t *testing.T) {
 }
 
 func TestInClusterGetAllValidTargets(t *testing.T) {
-	target := executioncluster.ExecutionTarget{}
+	target := &executioncluster.ExecutionTarget{
+		Enabled: true,
+	}
 	cluster := InCluster{
-		target: target,
+		target: *target,
 		asTargets: map[string]*executioncluster.ExecutionTarget{
-			target.ID: &target,
+			target.ID: target,
 		},
 	}
 	targets := cluster.GetValidTargets()
 	assert.Equal(t, 1, len(targets))
-	assert.Empty(t, targets[target.ID].ID)
+	assert.Equal(t, targets[target.ID], target)
 
 	targets = cluster.GetAllTargets()
 	assert.Equal(t, 1, len(targets))
-	assert.Empty(t, targets[target.ID].ID)
+	assert.Equal(t, targets[target.ID], target)
 }


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Consistently don't assign a cluster id for executions triggered in cluster.

Tested on flytesandbox.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2059

## Follow-up issue
_NA_
