### PR TITLE
Use domains from project list

### DIFF
--- a/pkg/clusterresource/controller_test.go
+++ b/pkg/clusterresource/controller_test.go
@@ -205,7 +205,7 @@ func Test_controller_createResourceFromTemplate(t *testing.T) {
 		templateDir          string
 		templateFileName     string
 		project              *admin.Project
-		domain               runtimeInterfaces.Domain
+		domain               *admin.Domain
 		namespace            NamespaceName
 		templateValues       templateValuesType
 		customTemplateValues templateValuesType
@@ -226,8 +226,8 @@ func Test_controller_createResourceFromTemplate(t *testing.T) {
 					Name: "my-project",
 					Id:   "my-project",
 				},
-				domain: runtimeInterfaces.Domain{
-					ID:   "dev",
+				domain: &admin.Domain{
+					Id:   "dev",
 					Name: "dev",
 				},
 				namespace:            "my-project-dev",
@@ -254,8 +254,8 @@ spec:
 					Name: "my-project",
 					Id:   "my-project",
 				},
-				domain: runtimeInterfaces.Domain{
-					ID:   "dev",
+				domain: &admin.Domain{
+					Id:   "dev",
 					Name: "dev",
 				},
 				namespace: "my-project-dev",
@@ -286,8 +286,8 @@ type: kubernetes.io/dockerconfigjson
 					Name: "my-project",
 					Id:   "my-project",
 				},
-				domain: runtimeInterfaces.Domain{
-					ID:   "dev",
+				domain: &admin.Domain{
+					Id:   "dev",
 					Name: "dev",
 				},
 				namespace:            "my-project-dev",
@@ -314,8 +314,8 @@ imagePullSecrets:
 					Name: "my-project",
 					Id:   "my-project",
 				},
-				domain: runtimeInterfaces.Domain{
-					ID:   "dev",
+				domain: &admin.Domain{
+					Id:   "dev",
 					Name: "dev",
 				},
 				namespace:            "my-project-dev",


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Rather than read domains from the application configuration, read them from the projects list provided by the FlyteAdminDataProvider interface.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See above

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2059

## Follow-up issue
_NA_
