### PR TITLE
Record aborting before making abort call

### DIFF
--- a/pkg/repositories/transformers/execution.go
+++ b/pkg/repositories/transformers/execution.go
@@ -269,7 +269,7 @@ func UpdateExecutionModelStateChangeDetails(executionModel *models.Execution, st
 
 // The execution abort metadata is recorded but the phase is not actually updated *until* the abort event is propagated
 // by flytepropeller. The metadata is preemptively saved at the time of the abort.
-func SetExecutionAborted(execution *models.Execution, cause, principal string) error {
+func SetExecutionAborting(execution *models.Execution, cause, principal string) error {
 	var closure admin.ExecutionClosure
 	err := proto.Unmarshal(execution.Closure, &closure)
 	if err != nil {

--- a/pkg/repositories/transformers/execution_test.go
+++ b/pkg/repositories/transformers/execution_test.go
@@ -446,7 +446,7 @@ func TestSetExecutionAborted(t *testing.T) {
 	}
 	cause := "a snafoo occurred"
 	principal := "principal"
-	err := SetExecutionAborted(&existingModel, cause, principal)
+	err := SetExecutionAborting(&existingModel, cause, principal)
 	assert.NoError(t, err)
 	var actualClosure admin.ExecutionClosure
 	err = proto.Unmarshal(existingModel.Closure, &actualClosure)


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
This ensures idempotency when calling Abort on the workflow executor fails.

Conversely, if the abort is too speedy, we could land in a situation where the workflow executor sends an "ABORT" event, which we record, and then we record the original "ABORTING" afterwards, leading to incorrect state.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
