### PR TITLE
Removed omit id on FirstOrCreate

### DIFF
--- a/pkg/repositories/gormimpl/resource_repo.go
+++ b/pkg/repositories/gormimpl/resource_repo.go
@@ -59,7 +59,7 @@ func (r *ResourceRepo) CreateOrUpdate(ctx context.Context, input models.Resource
 	}
 	timer := r.metrics.GetDuration.Start()
 	var record models.Resource
-	tx := r.db.Omit("id").FirstOrCreate(&record, models.Resource{
+	tx := r.db.FirstOrCreate(&record, models.Resource{
 		Project:      input.Project,
 		Domain:       input.Domain,
 		Workflow:     input.Workflow,

--- a/pkg/repositories/models/resource.go
+++ b/pkg/repositories/models/resource.go
@@ -18,11 +18,11 @@ type Resource struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	DeletedAt    *time.Time `sql:"index"`
-	Project      string     `gorm:"unique_index:resource_idx" valid:"length(0|255)"`
-	Domain       string     `gorm:"unique_index:resource_idx" valid:"length(0|255)"`
-	Workflow     string     `gorm:"unique_index:resource_idx" valid:"length(0|255)"`
-	LaunchPlan   string     `gorm:"unique_index:resource_idx" valid:"length(0|255)"`
-	ResourceType string     `gorm:"unique_index:resource_idx" valid:"length(0|255)"`
+	Project      string     `gorm:"uniqueIndex:resource_idx" valid:"length(0|255)"`
+	Domain       string     `gorm:"uniqueIndex:resource_idx" valid:"length(0|255)"`
+	Workflow     string     `gorm:"uniqueIndex:resource_idx" valid:"length(0|255)"`
+	LaunchPlan   string     `gorm:"uniqueIndex:resource_idx" valid:"length(0|255)"`
+	ResourceType string     `gorm:"uniqueIndex:resource_idx" valid:"length(0|255)"`
 	Priority     ResourcePriority
 	// Serialized flyteidl.admin.MatchingAttributes.
 	Attributes []byte

--- a/tests/attributes_test.go
+++ b/tests/attributes_test.go
@@ -41,8 +41,7 @@ func TestUpdateClusterResourceAttributes(t *testing.T) {
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
-
-	db, err := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getDbConfig(), adminScope))
+	db, err := repositories.GetDB(ctx, getDbConfig(), getLoggerConfig())
 	assert.Nil(t, err)
 	truncateTableForTesting(db, "resources")
 	sqlDB, err := db.DB()

--- a/tests/attributes_test.go
+++ b/tests/attributes_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package tests
@@ -24,6 +25,109 @@ var matchingAttributes = &admin.MatchingAttributes{
 			},
 		},
 	},
+}
+
+func TestUpdateClusterResourceAttributes(t *testing.T) {
+	matchingAttributes = &admin.MatchingAttributes{
+		Target: &admin.MatchingAttributes_ClusterResourceAttributes{
+			ClusterResourceAttributes: &admin.ClusterResourceAttributes{
+				Attributes: map[string]string{
+					"key": "value",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	client, conn := GetTestAdminServiceClient()
+	defer conn.Close()
+
+	db, err := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getDbConfig(), adminScope))
+	assert.Nil(t, err)
+	truncateTableForTesting(db, "resources")
+	sqlDB, err := db.DB()
+	assert.Nil(t, err)
+	err = sqlDB.Close()
+	assert.Nil(t, err)
+
+	req := admin.ProjectDomainAttributesUpdateRequest{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: matchingAttributes,
+		},
+	}
+
+	_, err = client.UpdateProjectDomainAttributes(ctx, &req)
+	fmt.Println(err)
+	assert.Nil(t, err)
+
+
+	listResp, err := client.ListMatchableAttributes(ctx, &admin.ListMatchableAttributesRequest{
+		ResourceType: admin.MatchableResource_CLUSTER_RESOURCE,
+	})
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(listResp.GetConfigurations()))
+
+	response, err := client.GetProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		ResourceType: admin.MatchableResource_CLUSTER_RESOURCE,
+	})
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.ProjectDomainAttributesGetResponse{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: matchingAttributes,
+		},
+	}, response))
+
+	var updatedMatchingAttributes = &admin.MatchingAttributes{
+		Target: &admin.MatchingAttributes_ClusterResourceAttributes{
+			ClusterResourceAttributes: &admin.ClusterResourceAttributes{
+				Attributes: map[string]string{
+					"key": "value2",
+				},
+			},
+		},
+	}
+	req = admin.ProjectDomainAttributesUpdateRequest{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: updatedMatchingAttributes,
+		},
+	}
+
+	_, err = client.UpdateProjectDomainAttributes(ctx, &req)
+	fmt.Println(err)
+	assert.Nil(t, err)
+
+	listResp, err = client.ListMatchableAttributes(ctx, &admin.ListMatchableAttributesRequest{
+		ResourceType: admin.MatchableResource_CLUSTER_RESOURCE,
+	})
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(listResp.GetConfigurations()))
+
+	response, err = client.GetProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		ResourceType: admin.MatchableResource_CLUSTER_RESOURCE,
+	})
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.ProjectDomainAttributesGetResponse{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: updatedMatchingAttributes,
+		},
+	}, response))
+
 }
 
 func TestUpdateProjectDomainAttributes(t *testing.T) {
@@ -62,6 +166,42 @@ func TestUpdateProjectDomainAttributes(t *testing.T) {
 			Project:            "admintests",
 			Domain:             "development",
 			MatchingAttributes: matchingAttributes,
+		},
+	}, response))
+
+	var updatedMatchingAttributes = &admin.MatchingAttributes{
+		Target: &admin.MatchingAttributes_TaskResourceAttributes{
+			TaskResourceAttributes: &admin.TaskResourceAttributes{
+				Defaults: &admin.TaskResourceSpec{
+					Cpu: "1",
+				},
+			},
+		},
+	}
+	req = admin.ProjectDomainAttributesUpdateRequest{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: updatedMatchingAttributes,
+		},
+	}
+
+	_, err = client.UpdateProjectDomainAttributes(ctx, &req)
+	fmt.Println(err)
+	assert.Nil(t, err)
+
+	response, err = client.GetProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.ProjectDomainAttributesGetResponse{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: updatedMatchingAttributes,
 		},
 	}, response))
 


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Omitting the ID on gorm FirstOrCreate results in not fetching the records correctly if they exist.
This causes multiple records being saved for the same project domain attribute.

Also added the missing update existing record test.

Added index due to which multiple records were being saved. This was an issue after gorm v2 upgrade.
```
flyteadmin=# \d resources;
                                        Table "public.resources"
    Column     |           Type           | Collation | Nullable |                Default                
---------------+--------------------------+-----------+----------+---------------------------------------
 id            | bigint                   |           | not null | nextval('resources_id_seq'::regclass)
 created_at    | timestamp with time zone |           |          | 
 updated_at    | timestamp with time zone |           |          | 
 deleted_at    | timestamp with time zone |           |          | 
 project       | text                     |           |          | 
 domain        | text                     |           |          | 
 workflow      | text                     |           |          | 
 launch_plan   | text                     |           |          | 
 resource_type | text                     |           |          | 
 priority      | integer                  |           |          | 
 attributes    | bytea                    |           |          | 
Indexes:
    "resources_pkey" PRIMARY KEY, btree (id)
    "resource_idx" UNIQUE, btree (project, domain, workflow, launch_plan, resource_type)
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/2210

## Follow-up issue
_NA_
