### PR TITLE
Linter fixes for using latest golangcli-lint

### DIFF
--- a/pkg/async/schedule/aws/cloud_watch_scheduler.go
+++ b/pkg/async/schedule/aws/cloud_watch_scheduler.go
@@ -204,7 +204,7 @@ func (s *cloudWatchScheduler) CreateScheduleInput(ctx context.Context, appConfig
 func isResourceNotFoundException(err error) bool {
 	switch err := err.(type) {
 	case awserr.Error:
-		return err.(awserr.Error).Code() == cloudwatchevents.ErrCodeResourceNotFoundException
+		return err.Code() == cloudwatchevents.ErrCodeResourceNotFoundException
 	}
 	return false
 }

--- a/pkg/audit/log.go
+++ b/pkg/audit/log.go
@@ -61,7 +61,7 @@ func (b *logBuilder) WithResponse(sentAt time.Time, err error) LogBuilder {
 	if err != nil {
 		switch err := err.(type) {
 		case errors.FlyteAdminError:
-			responseCode = err.(errors.FlyteAdminError).Code().String()
+			responseCode = err.Code().String()
 		default:
 			responseCode = codes.Internal.String()
 		}

--- a/pkg/repositories/errors/postgres_test.go
+++ b/pkg/repositories/errors/postgres_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	flyteAdminError "github.com/flyteorg/flyteadmin/pkg/errors"
 	mockScope "github.com/flyteorg/flytestdlib/promutils"
 
 	"github.com/jackc/pgconn"
@@ -15,8 +14,8 @@ import (
 func TestToFlyteAdminError_InvalidPqError(t *testing.T) {
 	err := errors.New("foo")
 	transformedErr := NewPostgresErrorTransformer(mockScope.NewTestScope()).ToFlyteAdminError(err)
-	assert.Equal(t, codes.Internal, transformedErr.(flyteAdminError.FlyteAdminError).Code())
-	assert.Equal(t, "unexpected error type for: foo", transformedErr.(flyteAdminError.FlyteAdminError).Error())
+	assert.Equal(t, codes.Internal, transformedErr.Code())
+	assert.Equal(t, "unexpected error type for: foo", transformedErr.Error())
 }
 
 func TestToFlyteAdminError_UniqueConstraintViolation(t *testing.T) {
@@ -25,9 +24,9 @@ func TestToFlyteAdminError_UniqueConstraintViolation(t *testing.T) {
 		Message: "message",
 	}
 	transformedErr := NewPostgresErrorTransformer(mockScope.NewTestScope()).ToFlyteAdminError(err)
-	assert.Equal(t, codes.AlreadyExists, transformedErr.(flyteAdminError.FlyteAdminError).Code())
+	assert.Equal(t, codes.AlreadyExists, transformedErr.Code())
 	assert.Equal(t, "value with matching already exists (message)",
-		transformedErr.(flyteAdminError.FlyteAdminError).Error())
+		transformedErr.Error())
 }
 
 func TestToFlyteAdminError_UnrecognizedPostgresError(t *testing.T) {
@@ -36,7 +35,7 @@ func TestToFlyteAdminError_UnrecognizedPostgresError(t *testing.T) {
 		Message: "message",
 	}
 	transformedErr := NewPostgresErrorTransformer(mockScope.NewTestScope()).ToFlyteAdminError(err)
-	assert.Equal(t, codes.Unknown, transformedErr.(flyteAdminError.FlyteAdminError).Code())
+	assert.Equal(t, codes.Unknown, transformedErr.Code())
 	assert.Equal(t, "failed database operation with message",
-		transformedErr.(flyteAdminError.FlyteAdminError).Error())
+		transformedErr.Error())
 }


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>


# TL;DR
Following boilerplate PR failed https://github.com/flyteorg/flyteadmin/pull/363  due to an update to latest golang-cli which has new error code S1040 ( type assertion to the same type) 
This fixes the issue raised by the latest golangclit-lint


## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
