### PR TITLE
Fix bug to actually enable cluster reassignment on Queued events

### DIFF
--- a/tests/attributes_test.go
+++ b/tests/attributes_test.go
@@ -61,7 +61,6 @@ func TestUpdateClusterResourceAttributes(t *testing.T) {
 	fmt.Println(err)
 	assert.Nil(t, err)
 
-
 	listResp, err := client.ListMatchableAttributes(ctx, &admin.ListMatchableAttributesRequest{
 		ResourceType: admin.MatchableResource_CLUSTER_RESOURCE,
 	})


### PR DESCRIPTION
# TL;DR
Bug accidentally introduced in https://github.com/flyteorg/flyteadmin/pull/348. This change ensures that we can indeed reassign the cluster on queued events.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/flyteorg/flyte/issues/1929

## Follow-up issue
_NA_
