### PR TITLE
Add created_at index to executions

### DIFF
--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -380,6 +380,16 @@ var Migrations = []*gormigrate.Migration{
 			return tx.Table("node_execution").Migrator().DropColumn(&NodeExecution{}, "internal_data")
 		},
 	},
+	// Add created_at index to the execution model.
+	{
+		ID: "2022-04-04-execution-created-at-index",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&models.Execution{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Model(&models.Execution{}).Migrator().DropIndex(&models.Execution{}, "idx_executions_created_at")
+		},
+	},
 }
 
 func alterTableColumnType(db *sql.DB, columnName, columnType string) error {

--- a/pkg/repositories/models/execution.go
+++ b/pkg/repositories/models/execution.go
@@ -29,7 +29,7 @@ type Execution struct {
 	StartedAt    *time.Time
 	// Corresponds to the CreatedAt field in the Execution closure.
 	// Prefixed with Execution to avoid clashes with gorm.Model CreatedAt
-	ExecutionCreatedAt *time.Time
+	ExecutionCreatedAt *time.Time `gorm:"index:idx_executions_created_at"`
 	// Corresponds to the UpdatedAt field in the Execution closure
 	// Prefixed with Execution to avoid clashes with gorm.Model UpdatedAt
 	ExecutionUpdatedAt *time.Time


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Add created_at index to executions to support workflow landing page in console which shows the most recent executions

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2319

## Follow-up issue
_NA_
