### PR TITLE
Update scheduler.Dockerfile to go 1.18 to match admin

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,7 @@ jobs:
       version: ${{ needs.bump_version.outputs.version }}
       push: true
       repository: flyteorg/flytescheduler
-      dockerfile: Dockerfile.scheduler
+      dockerfile: scheduler.Dockerfile
     secrets:
       FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
       FLYTE_BOT_USERNAME: ${{ secrets.FLYTE_BOT_USERNAME }}

--- a/scheduler.Dockerfile
+++ b/scheduler.Dockerfile
@@ -3,7 +3,7 @@
 # 
 # TO OPT OUT OF UPDATES, SEE https://github.com/lyft/boilerplate/blob/master/Readme.rst
 
-FROM golang:1.16.0-alpine3.13 as builder
+FROM golang:1.18-alpine3.15 as builder
 RUN apk add git openssh-client make curl
 
 # COPY only the go mod files for efficient caching
@@ -24,7 +24,7 @@ RUN make linux_compile_scheduler
 ENV PATH="/artifacts:${PATH}"
 
 # This will eventually move to centurylink/ca-certs:latest for minimum possible image size
-FROM alpine:3.13
+FROM alpine:3.15
 LABEL org.opencontainers.image.source https://github.com/flyteorg/flyteadmin
 
 COPY --from=builder /artifacts /bin


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
We've updated admin a while ago to build using go 1.18 but scheduler.Dockerfile was missed in the process.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin
