### PR TITLE
Configure IgnoreRecordNotFoundError in gorm logger

### DIFF
--- a/pkg/repositories/database_test.go
+++ b/pkg/repositories/database_test.go
@@ -16,33 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	gormLogger "gorm.io/gorm/logger"
 )
-
-func TestGetGormLogLevel(t *testing.T) {
-	assert.Equal(t, gormLogger.Error, getGormLogLevel(context.TODO(), &logger.Config{
-		Level: logger.PanicLevel,
-	}))
-	assert.Equal(t, gormLogger.Error, getGormLogLevel(context.TODO(), &logger.Config{
-		Level: logger.FatalLevel,
-	}))
-	assert.Equal(t, gormLogger.Error, getGormLogLevel(context.TODO(), &logger.Config{
-		Level: logger.ErrorLevel,
-	}))
-
-	assert.Equal(t, gormLogger.Warn, getGormLogLevel(context.TODO(), &logger.Config{
-		Level: logger.WarnLevel,
-	}))
-
-	assert.Equal(t, gormLogger.Info, getGormLogLevel(context.TODO(), &logger.Config{
-		Level: logger.InfoLevel,
-	}))
-	assert.Equal(t, gormLogger.Info, getGormLogLevel(context.TODO(), &logger.Config{
-		Level: logger.DebugLevel,
-	}))
-
-	assert.Equal(t, gormLogger.Error, getGormLogLevel(context.TODO(), nil))
-}
 
 func TestResolvePassword(t *testing.T) {
 	password := "123abc"


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Configure IgnoreRecordNotFoundError in gorm logger

I had to remove the existing unit tests because the gorm logger interface doesn't expose its config

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Part of an ongoing investigation into flyteadmin memory pressure

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2324

## Follow-up issue
_NA_
