### PR TITLE
Deep check on security context

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -452,9 +452,14 @@ func mergeIntoExecConfig(workflowExecConfig *admin.WorkflowExecutionConfig, spec
 		workflowExecConfig.MaxParallelism = spec.GetMaxParallelism()
 		isChanged = true
 	}
+
 	if workflowExecConfig.GetSecurityContext() == nil && spec.GetSecurityContext() != nil {
-		workflowExecConfig.SecurityContext = spec.GetSecurityContext()
-		isChanged = true
+		if spec.GetSecurityContext().GetRunAs() != nil &&
+			(len(spec.GetSecurityContext().GetRunAs().GetK8SServiceAccount()) > 0 ||
+				len(spec.GetSecurityContext().GetRunAs().GetIamRole()) > 0) {
+			workflowExecConfig.SecurityContext = spec.GetSecurityContext()
+			isChanged = true
+		}
 	}
 	// Launchplan spec has label, annotation and rawOutputDataConfig initialized with empty values.
 	// Hence we do a deep check in the following conditions before assignment


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
 During testing of the project-domain setting for workflow execution config discovered that UI passes empty security context 
This causes the workflow execution config to be picked from this empty context which causes the executions to be launched using default service account which is incorrect since it should have checked further in launchplan spec , matchable attribute , application config in that order.

This PR fixes the issue by doing a deep check on the security context.


## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue

 https://github.com/flyteorg/flyte/issues/2070

## Follow-up issue
_NA_
