### PR TITLE
Getting security context from the resolved execution parameters

### DIFF
--- a/auth/interfaces/mocks/authentication_context.go
+++ b/auth/interfaces/mocks/authentication_context.go
@@ -34,13 +34,13 @@ func (_m AuthenticationContext_AuthMetadataService) Return(_a0 service.AuthMetad
 }
 
 func (_m *AuthenticationContext) OnAuthMetadataService() *AuthenticationContext_AuthMetadataService {
-	c := _m.On("AuthMetadataService")
-	return &AuthenticationContext_AuthMetadataService{Call: c}
+	c_call := _m.On("AuthMetadataService")
+	return &AuthenticationContext_AuthMetadataService{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnAuthMetadataServiceMatch(matchers ...interface{}) *AuthenticationContext_AuthMetadataService {
-	c := _m.On("AuthMetadataService", matchers...)
-	return &AuthenticationContext_AuthMetadataService{Call: c}
+	c_call := _m.On("AuthMetadataService", matchers...)
+	return &AuthenticationContext_AuthMetadataService{Call: c_call}
 }
 
 // AuthMetadataService provides a mock function with given fields:
@@ -68,13 +68,13 @@ func (_m AuthenticationContext_CookieManager) Return(_a0 interfaces.CookieHandle
 }
 
 func (_m *AuthenticationContext) OnCookieManager() *AuthenticationContext_CookieManager {
-	c := _m.On("CookieManager")
-	return &AuthenticationContext_CookieManager{Call: c}
+	c_call := _m.On("CookieManager")
+	return &AuthenticationContext_CookieManager{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnCookieManagerMatch(matchers ...interface{}) *AuthenticationContext_CookieManager {
-	c := _m.On("CookieManager", matchers...)
-	return &AuthenticationContext_CookieManager{Call: c}
+	c_call := _m.On("CookieManager", matchers...)
+	return &AuthenticationContext_CookieManager{Call: c_call}
 }
 
 // CookieManager provides a mock function with given fields:
@@ -102,13 +102,13 @@ func (_m AuthenticationContext_GetHTTPClient) Return(_a0 *http.Client) *Authenti
 }
 
 func (_m *AuthenticationContext) OnGetHTTPClient() *AuthenticationContext_GetHTTPClient {
-	c := _m.On("GetHTTPClient")
-	return &AuthenticationContext_GetHTTPClient{Call: c}
+	c_call := _m.On("GetHTTPClient")
+	return &AuthenticationContext_GetHTTPClient{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnGetHTTPClientMatch(matchers ...interface{}) *AuthenticationContext_GetHTTPClient {
-	c := _m.On("GetHTTPClient", matchers...)
-	return &AuthenticationContext_GetHTTPClient{Call: c}
+	c_call := _m.On("GetHTTPClient", matchers...)
+	return &AuthenticationContext_GetHTTPClient{Call: c_call}
 }
 
 // GetHTTPClient provides a mock function with given fields:
@@ -136,13 +136,13 @@ func (_m AuthenticationContext_GetOAuth2MetadataURL) Return(_a0 *url.URL) *Authe
 }
 
 func (_m *AuthenticationContext) OnGetOAuth2MetadataURL() *AuthenticationContext_GetOAuth2MetadataURL {
-	c := _m.On("GetOAuth2MetadataURL")
-	return &AuthenticationContext_GetOAuth2MetadataURL{Call: c}
+	c_call := _m.On("GetOAuth2MetadataURL")
+	return &AuthenticationContext_GetOAuth2MetadataURL{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnGetOAuth2MetadataURLMatch(matchers ...interface{}) *AuthenticationContext_GetOAuth2MetadataURL {
-	c := _m.On("GetOAuth2MetadataURL", matchers...)
-	return &AuthenticationContext_GetOAuth2MetadataURL{Call: c}
+	c_call := _m.On("GetOAuth2MetadataURL", matchers...)
+	return &AuthenticationContext_GetOAuth2MetadataURL{Call: c_call}
 }
 
 // GetOAuth2MetadataURL provides a mock function with given fields:
@@ -170,13 +170,13 @@ func (_m AuthenticationContext_GetOIdCMetadataURL) Return(_a0 *url.URL) *Authent
 }
 
 func (_m *AuthenticationContext) OnGetOIdCMetadataURL() *AuthenticationContext_GetOIdCMetadataURL {
-	c := _m.On("GetOIdCMetadataURL")
-	return &AuthenticationContext_GetOIdCMetadataURL{Call: c}
+	c_call := _m.On("GetOIdCMetadataURL")
+	return &AuthenticationContext_GetOIdCMetadataURL{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnGetOIdCMetadataURLMatch(matchers ...interface{}) *AuthenticationContext_GetOIdCMetadataURL {
-	c := _m.On("GetOIdCMetadataURL", matchers...)
-	return &AuthenticationContext_GetOIdCMetadataURL{Call: c}
+	c_call := _m.On("GetOIdCMetadataURL", matchers...)
+	return &AuthenticationContext_GetOIdCMetadataURL{Call: c_call}
 }
 
 // GetOIdCMetadataURL provides a mock function with given fields:
@@ -204,13 +204,13 @@ func (_m AuthenticationContext_IdentityService) Return(_a0 service.IdentityServi
 }
 
 func (_m *AuthenticationContext) OnIdentityService() *AuthenticationContext_IdentityService {
-	c := _m.On("IdentityService")
-	return &AuthenticationContext_IdentityService{Call: c}
+	c_call := _m.On("IdentityService")
+	return &AuthenticationContext_IdentityService{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnIdentityServiceMatch(matchers ...interface{}) *AuthenticationContext_IdentityService {
-	c := _m.On("IdentityService", matchers...)
-	return &AuthenticationContext_IdentityService{Call: c}
+	c_call := _m.On("IdentityService", matchers...)
+	return &AuthenticationContext_IdentityService{Call: c_call}
 }
 
 // IdentityService provides a mock function with given fields:
@@ -238,13 +238,13 @@ func (_m AuthenticationContext_OAuth2ClientConfig) Return(_a0 *oauth2.Config) *A
 }
 
 func (_m *AuthenticationContext) OnOAuth2ClientConfig(requestURL *url.URL) *AuthenticationContext_OAuth2ClientConfig {
-	c := _m.On("OAuth2ClientConfig", requestURL)
-	return &AuthenticationContext_OAuth2ClientConfig{Call: c}
+	c_call := _m.On("OAuth2ClientConfig", requestURL)
+	return &AuthenticationContext_OAuth2ClientConfig{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnOAuth2ClientConfigMatch(matchers ...interface{}) *AuthenticationContext_OAuth2ClientConfig {
-	c := _m.On("OAuth2ClientConfig", matchers...)
-	return &AuthenticationContext_OAuth2ClientConfig{Call: c}
+	c_call := _m.On("OAuth2ClientConfig", matchers...)
+	return &AuthenticationContext_OAuth2ClientConfig{Call: c_call}
 }
 
 // OAuth2ClientConfig provides a mock function with given fields: requestURL
@@ -272,13 +272,13 @@ func (_m AuthenticationContext_OAuth2Provider) Return(_a0 interfaces.OAuth2Provi
 }
 
 func (_m *AuthenticationContext) OnOAuth2Provider() *AuthenticationContext_OAuth2Provider {
-	c := _m.On("OAuth2Provider")
-	return &AuthenticationContext_OAuth2Provider{Call: c}
+	c_call := _m.On("OAuth2Provider")
+	return &AuthenticationContext_OAuth2Provider{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnOAuth2ProviderMatch(matchers ...interface{}) *AuthenticationContext_OAuth2Provider {
-	c := _m.On("OAuth2Provider", matchers...)
-	return &AuthenticationContext_OAuth2Provider{Call: c}
+	c_call := _m.On("OAuth2Provider", matchers...)
+	return &AuthenticationContext_OAuth2Provider{Call: c_call}
 }
 
 // OAuth2Provider provides a mock function with given fields:
@@ -306,13 +306,13 @@ func (_m AuthenticationContext_OAuth2ResourceServer) Return(_a0 interfaces.OAuth
 }
 
 func (_m *AuthenticationContext) OnOAuth2ResourceServer() *AuthenticationContext_OAuth2ResourceServer {
-	c := _m.On("OAuth2ResourceServer")
-	return &AuthenticationContext_OAuth2ResourceServer{Call: c}
+	c_call := _m.On("OAuth2ResourceServer")
+	return &AuthenticationContext_OAuth2ResourceServer{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnOAuth2ResourceServerMatch(matchers ...interface{}) *AuthenticationContext_OAuth2ResourceServer {
-	c := _m.On("OAuth2ResourceServer", matchers...)
-	return &AuthenticationContext_OAuth2ResourceServer{Call: c}
+	c_call := _m.On("OAuth2ResourceServer", matchers...)
+	return &AuthenticationContext_OAuth2ResourceServer{Call: c_call}
 }
 
 // OAuth2ResourceServer provides a mock function with given fields:
@@ -340,13 +340,13 @@ func (_m AuthenticationContext_OidcProvider) Return(_a0 *oidc.Provider) *Authent
 }
 
 func (_m *AuthenticationContext) OnOidcProvider() *AuthenticationContext_OidcProvider {
-	c := _m.On("OidcProvider")
-	return &AuthenticationContext_OidcProvider{Call: c}
+	c_call := _m.On("OidcProvider")
+	return &AuthenticationContext_OidcProvider{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnOidcProviderMatch(matchers ...interface{}) *AuthenticationContext_OidcProvider {
-	c := _m.On("OidcProvider", matchers...)
-	return &AuthenticationContext_OidcProvider{Call: c}
+	c_call := _m.On("OidcProvider", matchers...)
+	return &AuthenticationContext_OidcProvider{Call: c_call}
 }
 
 // OidcProvider provides a mock function with given fields:
@@ -374,13 +374,13 @@ func (_m AuthenticationContext_Options) Return(_a0 *config.Config) *Authenticati
 }
 
 func (_m *AuthenticationContext) OnOptions() *AuthenticationContext_Options {
-	c := _m.On("Options")
-	return &AuthenticationContext_Options{Call: c}
+	c_call := _m.On("Options")
+	return &AuthenticationContext_Options{Call: c_call}
 }
 
 func (_m *AuthenticationContext) OnOptionsMatch(matchers ...interface{}) *AuthenticationContext_Options {
-	c := _m.On("Options", matchers...)
-	return &AuthenticationContext_Options{Call: c}
+	c_call := _m.On("Options", matchers...)
+	return &AuthenticationContext_Options{Call: c_call}
 }
 
 // Options provides a mock function with given fields:

--- a/auth/interfaces/mocks/cookie_handler.go
+++ b/auth/interfaces/mocks/cookie_handler.go
@@ -32,13 +32,13 @@ func (_m CookieHandler_RetrieveAuthCodeRequest) Return(authRequestURL string, er
 }
 
 func (_m *CookieHandler) OnRetrieveAuthCodeRequest(ctx context.Context, request *http.Request) *CookieHandler_RetrieveAuthCodeRequest {
-	c := _m.On("RetrieveAuthCodeRequest", ctx, request)
-	return &CookieHandler_RetrieveAuthCodeRequest{Call: c}
+	c_call := _m.On("RetrieveAuthCodeRequest", ctx, request)
+	return &CookieHandler_RetrieveAuthCodeRequest{Call: c_call}
 }
 
 func (_m *CookieHandler) OnRetrieveAuthCodeRequestMatch(matchers ...interface{}) *CookieHandler_RetrieveAuthCodeRequest {
-	c := _m.On("RetrieveAuthCodeRequest", matchers...)
-	return &CookieHandler_RetrieveAuthCodeRequest{Call: c}
+	c_call := _m.On("RetrieveAuthCodeRequest", matchers...)
+	return &CookieHandler_RetrieveAuthCodeRequest{Call: c_call}
 }
 
 // RetrieveAuthCodeRequest provides a mock function with given fields: ctx, request
@@ -71,13 +71,13 @@ func (_m CookieHandler_RetrieveTokenValues) Return(idToken string, accessToken s
 }
 
 func (_m *CookieHandler) OnRetrieveTokenValues(ctx context.Context, request *http.Request) *CookieHandler_RetrieveTokenValues {
-	c := _m.On("RetrieveTokenValues", ctx, request)
-	return &CookieHandler_RetrieveTokenValues{Call: c}
+	c_call := _m.On("RetrieveTokenValues", ctx, request)
+	return &CookieHandler_RetrieveTokenValues{Call: c_call}
 }
 
 func (_m *CookieHandler) OnRetrieveTokenValuesMatch(matchers ...interface{}) *CookieHandler_RetrieveTokenValues {
-	c := _m.On("RetrieveTokenValues", matchers...)
-	return &CookieHandler_RetrieveTokenValues{Call: c}
+	c_call := _m.On("RetrieveTokenValues", matchers...)
+	return &CookieHandler_RetrieveTokenValues{Call: c_call}
 }
 
 // RetrieveTokenValues provides a mock function with given fields: ctx, request
@@ -124,13 +124,13 @@ func (_m CookieHandler_RetrieveUserInfo) Return(_a0 *service.UserInfoResponse, _
 }
 
 func (_m *CookieHandler) OnRetrieveUserInfo(ctx context.Context, request *http.Request) *CookieHandler_RetrieveUserInfo {
-	c := _m.On("RetrieveUserInfo", ctx, request)
-	return &CookieHandler_RetrieveUserInfo{Call: c}
+	c_call := _m.On("RetrieveUserInfo", ctx, request)
+	return &CookieHandler_RetrieveUserInfo{Call: c_call}
 }
 
 func (_m *CookieHandler) OnRetrieveUserInfoMatch(matchers ...interface{}) *CookieHandler_RetrieveUserInfo {
-	c := _m.On("RetrieveUserInfo", matchers...)
-	return &CookieHandler_RetrieveUserInfo{Call: c}
+	c_call := _m.On("RetrieveUserInfo", matchers...)
+	return &CookieHandler_RetrieveUserInfo{Call: c_call}
 }
 
 // RetrieveUserInfo provides a mock function with given fields: ctx, request
@@ -165,13 +165,13 @@ func (_m CookieHandler_SetAuthCodeCookie) Return(_a0 error) *CookieHandler_SetAu
 }
 
 func (_m *CookieHandler) OnSetAuthCodeCookie(ctx context.Context, writer http.ResponseWriter, authRequestURL string) *CookieHandler_SetAuthCodeCookie {
-	c := _m.On("SetAuthCodeCookie", ctx, writer, authRequestURL)
-	return &CookieHandler_SetAuthCodeCookie{Call: c}
+	c_call := _m.On("SetAuthCodeCookie", ctx, writer, authRequestURL)
+	return &CookieHandler_SetAuthCodeCookie{Call: c_call}
 }
 
 func (_m *CookieHandler) OnSetAuthCodeCookieMatch(matchers ...interface{}) *CookieHandler_SetAuthCodeCookie {
-	c := _m.On("SetAuthCodeCookie", matchers...)
-	return &CookieHandler_SetAuthCodeCookie{Call: c}
+	c_call := _m.On("SetAuthCodeCookie", matchers...)
+	return &CookieHandler_SetAuthCodeCookie{Call: c_call}
 }
 
 // SetAuthCodeCookie provides a mock function with given fields: ctx, writer, authRequestURL
@@ -197,13 +197,13 @@ func (_m CookieHandler_SetTokenCookies) Return(_a0 error) *CookieHandler_SetToke
 }
 
 func (_m *CookieHandler) OnSetTokenCookies(ctx context.Context, writer http.ResponseWriter, token *oauth2.Token) *CookieHandler_SetTokenCookies {
-	c := _m.On("SetTokenCookies", ctx, writer, token)
-	return &CookieHandler_SetTokenCookies{Call: c}
+	c_call := _m.On("SetTokenCookies", ctx, writer, token)
+	return &CookieHandler_SetTokenCookies{Call: c_call}
 }
 
 func (_m *CookieHandler) OnSetTokenCookiesMatch(matchers ...interface{}) *CookieHandler_SetTokenCookies {
-	c := _m.On("SetTokenCookies", matchers...)
-	return &CookieHandler_SetTokenCookies{Call: c}
+	c_call := _m.On("SetTokenCookies", matchers...)
+	return &CookieHandler_SetTokenCookies{Call: c_call}
 }
 
 // SetTokenCookies provides a mock function with given fields: ctx, writer, token
@@ -229,13 +229,13 @@ func (_m CookieHandler_SetUserInfoCookie) Return(_a0 error) *CookieHandler_SetUs
 }
 
 func (_m *CookieHandler) OnSetUserInfoCookie(ctx context.Context, writer http.ResponseWriter, userInfo *service.UserInfoResponse) *CookieHandler_SetUserInfoCookie {
-	c := _m.On("SetUserInfoCookie", ctx, writer, userInfo)
-	return &CookieHandler_SetUserInfoCookie{Call: c}
+	c_call := _m.On("SetUserInfoCookie", ctx, writer, userInfo)
+	return &CookieHandler_SetUserInfoCookie{Call: c_call}
 }
 
 func (_m *CookieHandler) OnSetUserInfoCookieMatch(matchers ...interface{}) *CookieHandler_SetUserInfoCookie {
-	c := _m.On("SetUserInfoCookie", matchers...)
-	return &CookieHandler_SetUserInfoCookie{Call: c}
+	c_call := _m.On("SetUserInfoCookie", matchers...)
+	return &CookieHandler_SetUserInfoCookie{Call: c_call}
 }
 
 // SetUserInfoCookie provides a mock function with given fields: ctx, writer, userInfo

--- a/auth/interfaces/mocks/identity_context.go
+++ b/auth/interfaces/mocks/identity_context.go
@@ -28,13 +28,13 @@ func (_m IdentityContext_AppID) Return(_a0 string) *IdentityContext_AppID {
 }
 
 func (_m *IdentityContext) OnAppID() *IdentityContext_AppID {
-	c := _m.On("AppID")
-	return &IdentityContext_AppID{Call: c}
+	c_call := _m.On("AppID")
+	return &IdentityContext_AppID{Call: c_call}
 }
 
 func (_m *IdentityContext) OnAppIDMatch(matchers ...interface{}) *IdentityContext_AppID {
-	c := _m.On("AppID", matchers...)
-	return &IdentityContext_AppID{Call: c}
+	c_call := _m.On("AppID", matchers...)
+	return &IdentityContext_AppID{Call: c_call}
 }
 
 // AppID provides a mock function with given fields:
@@ -60,13 +60,13 @@ func (_m IdentityContext_Audience) Return(_a0 string) *IdentityContext_Audience 
 }
 
 func (_m *IdentityContext) OnAudience() *IdentityContext_Audience {
-	c := _m.On("Audience")
-	return &IdentityContext_Audience{Call: c}
+	c_call := _m.On("Audience")
+	return &IdentityContext_Audience{Call: c_call}
 }
 
 func (_m *IdentityContext) OnAudienceMatch(matchers ...interface{}) *IdentityContext_Audience {
-	c := _m.On("Audience", matchers...)
-	return &IdentityContext_Audience{Call: c}
+	c_call := _m.On("Audience", matchers...)
+	return &IdentityContext_Audience{Call: c_call}
 }
 
 // Audience provides a mock function with given fields:
@@ -92,13 +92,13 @@ func (_m IdentityContext_AuthenticatedAt) Return(_a0 time.Time) *IdentityContext
 }
 
 func (_m *IdentityContext) OnAuthenticatedAt() *IdentityContext_AuthenticatedAt {
-	c := _m.On("AuthenticatedAt")
-	return &IdentityContext_AuthenticatedAt{Call: c}
+	c_call := _m.On("AuthenticatedAt")
+	return &IdentityContext_AuthenticatedAt{Call: c_call}
 }
 
 func (_m *IdentityContext) OnAuthenticatedAtMatch(matchers ...interface{}) *IdentityContext_AuthenticatedAt {
-	c := _m.On("AuthenticatedAt", matchers...)
-	return &IdentityContext_AuthenticatedAt{Call: c}
+	c_call := _m.On("AuthenticatedAt", matchers...)
+	return &IdentityContext_AuthenticatedAt{Call: c_call}
 }
 
 // AuthenticatedAt provides a mock function with given fields:
@@ -124,13 +124,13 @@ func (_m IdentityContext_IsEmpty) Return(_a0 bool) *IdentityContext_IsEmpty {
 }
 
 func (_m *IdentityContext) OnIsEmpty() *IdentityContext_IsEmpty {
-	c := _m.On("IsEmpty")
-	return &IdentityContext_IsEmpty{Call: c}
+	c_call := _m.On("IsEmpty")
+	return &IdentityContext_IsEmpty{Call: c_call}
 }
 
 func (_m *IdentityContext) OnIsEmptyMatch(matchers ...interface{}) *IdentityContext_IsEmpty {
-	c := _m.On("IsEmpty", matchers...)
-	return &IdentityContext_IsEmpty{Call: c}
+	c_call := _m.On("IsEmpty", matchers...)
+	return &IdentityContext_IsEmpty{Call: c_call}
 }
 
 // IsEmpty provides a mock function with given fields:
@@ -156,13 +156,13 @@ func (_m IdentityContext_Scopes) Return(_a0 sets.String) *IdentityContext_Scopes
 }
 
 func (_m *IdentityContext) OnScopes() *IdentityContext_Scopes {
-	c := _m.On("Scopes")
-	return &IdentityContext_Scopes{Call: c}
+	c_call := _m.On("Scopes")
+	return &IdentityContext_Scopes{Call: c_call}
 }
 
 func (_m *IdentityContext) OnScopesMatch(matchers ...interface{}) *IdentityContext_Scopes {
-	c := _m.On("Scopes", matchers...)
-	return &IdentityContext_Scopes{Call: c}
+	c_call := _m.On("Scopes", matchers...)
+	return &IdentityContext_Scopes{Call: c_call}
 }
 
 // Scopes provides a mock function with given fields:
@@ -190,13 +190,13 @@ func (_m IdentityContext_UserID) Return(_a0 string) *IdentityContext_UserID {
 }
 
 func (_m *IdentityContext) OnUserID() *IdentityContext_UserID {
-	c := _m.On("UserID")
-	return &IdentityContext_UserID{Call: c}
+	c_call := _m.On("UserID")
+	return &IdentityContext_UserID{Call: c_call}
 }
 
 func (_m *IdentityContext) OnUserIDMatch(matchers ...interface{}) *IdentityContext_UserID {
-	c := _m.On("UserID", matchers...)
-	return &IdentityContext_UserID{Call: c}
+	c_call := _m.On("UserID", matchers...)
+	return &IdentityContext_UserID{Call: c_call}
 }
 
 // UserID provides a mock function with given fields:
@@ -222,13 +222,13 @@ func (_m IdentityContext_UserInfo) Return(_a0 *service.UserInfoResponse) *Identi
 }
 
 func (_m *IdentityContext) OnUserInfo() *IdentityContext_UserInfo {
-	c := _m.On("UserInfo")
-	return &IdentityContext_UserInfo{Call: c}
+	c_call := _m.On("UserInfo")
+	return &IdentityContext_UserInfo{Call: c_call}
 }
 
 func (_m *IdentityContext) OnUserInfoMatch(matchers ...interface{}) *IdentityContext_UserInfo {
-	c := _m.On("UserInfo", matchers...)
-	return &IdentityContext_UserInfo{Call: c}
+	c_call := _m.On("UserInfo", matchers...)
+	return &IdentityContext_UserInfo{Call: c_call}
 }
 
 // UserInfo provides a mock function with given fields:
@@ -256,13 +256,13 @@ func (_m IdentityContext_WithContext) Return(_a0 context.Context) *IdentityConte
 }
 
 func (_m *IdentityContext) OnWithContext(ctx context.Context) *IdentityContext_WithContext {
-	c := _m.On("WithContext", ctx)
-	return &IdentityContext_WithContext{Call: c}
+	c_call := _m.On("WithContext", ctx)
+	return &IdentityContext_WithContext{Call: c_call}
 }
 
 func (_m *IdentityContext) OnWithContextMatch(matchers ...interface{}) *IdentityContext_WithContext {
-	c := _m.On("WithContext", matchers...)
-	return &IdentityContext_WithContext{Call: c}
+	c_call := _m.On("WithContext", matchers...)
+	return &IdentityContext_WithContext{Call: c_call}
 }
 
 // WithContext provides a mock function with given fields: ctx

--- a/auth/interfaces/mocks/o_auth2_provider.go
+++ b/auth/interfaces/mocks/o_auth2_provider.go
@@ -34,13 +34,13 @@ func (_m OAuth2Provider_IntrospectToken) Return(_a0 fosite.TokenType, _a1 fosite
 }
 
 func (_m *OAuth2Provider) OnIntrospectToken(ctx context.Context, token string, tokenUse fosite.TokenType, session fosite.Session, scope ...string) *OAuth2Provider_IntrospectToken {
-	c := _m.On("IntrospectToken", ctx, token, tokenUse, session, scope)
-	return &OAuth2Provider_IntrospectToken{Call: c}
+	c_call := _m.On("IntrospectToken", ctx, token, tokenUse, session, scope)
+	return &OAuth2Provider_IntrospectToken{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnIntrospectTokenMatch(matchers ...interface{}) *OAuth2Provider_IntrospectToken {
-	c := _m.On("IntrospectToken", matchers...)
-	return &OAuth2Provider_IntrospectToken{Call: c}
+	c_call := _m.On("IntrospectToken", matchers...)
+	return &OAuth2Provider_IntrospectToken{Call: c_call}
 }
 
 // IntrospectToken provides a mock function with given fields: ctx, token, tokenUse, session, scope
@@ -89,13 +89,13 @@ func (_m OAuth2Provider_KeySet) Return(_a0 jwk.Set) *OAuth2Provider_KeySet {
 }
 
 func (_m *OAuth2Provider) OnKeySet() *OAuth2Provider_KeySet {
-	c := _m.On("KeySet")
-	return &OAuth2Provider_KeySet{Call: c}
+	c_call := _m.On("KeySet")
+	return &OAuth2Provider_KeySet{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnKeySetMatch(matchers ...interface{}) *OAuth2Provider_KeySet {
-	c := _m.On("KeySet", matchers...)
-	return &OAuth2Provider_KeySet{Call: c}
+	c_call := _m.On("KeySet", matchers...)
+	return &OAuth2Provider_KeySet{Call: c_call}
 }
 
 // KeySet provides a mock function with given fields:
@@ -123,13 +123,13 @@ func (_m OAuth2Provider_NewAccessRequest) Return(_a0 fosite.AccessRequester, _a1
 }
 
 func (_m *OAuth2Provider) OnNewAccessRequest(ctx context.Context, req *http.Request, session fosite.Session) *OAuth2Provider_NewAccessRequest {
-	c := _m.On("NewAccessRequest", ctx, req, session)
-	return &OAuth2Provider_NewAccessRequest{Call: c}
+	c_call := _m.On("NewAccessRequest", ctx, req, session)
+	return &OAuth2Provider_NewAccessRequest{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewAccessRequestMatch(matchers ...interface{}) *OAuth2Provider_NewAccessRequest {
-	c := _m.On("NewAccessRequest", matchers...)
-	return &OAuth2Provider_NewAccessRequest{Call: c}
+	c_call := _m.On("NewAccessRequest", matchers...)
+	return &OAuth2Provider_NewAccessRequest{Call: c_call}
 }
 
 // NewAccessRequest provides a mock function with given fields: ctx, req, session
@@ -164,13 +164,13 @@ func (_m OAuth2Provider_NewAccessResponse) Return(_a0 fosite.AccessResponder, _a
 }
 
 func (_m *OAuth2Provider) OnNewAccessResponse(ctx context.Context, requester fosite.AccessRequester) *OAuth2Provider_NewAccessResponse {
-	c := _m.On("NewAccessResponse", ctx, requester)
-	return &OAuth2Provider_NewAccessResponse{Call: c}
+	c_call := _m.On("NewAccessResponse", ctx, requester)
+	return &OAuth2Provider_NewAccessResponse{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewAccessResponseMatch(matchers ...interface{}) *OAuth2Provider_NewAccessResponse {
-	c := _m.On("NewAccessResponse", matchers...)
-	return &OAuth2Provider_NewAccessResponse{Call: c}
+	c_call := _m.On("NewAccessResponse", matchers...)
+	return &OAuth2Provider_NewAccessResponse{Call: c_call}
 }
 
 // NewAccessResponse provides a mock function with given fields: ctx, requester
@@ -205,13 +205,13 @@ func (_m OAuth2Provider_NewAuthorizeRequest) Return(_a0 fosite.AuthorizeRequeste
 }
 
 func (_m *OAuth2Provider) OnNewAuthorizeRequest(ctx context.Context, req *http.Request) *OAuth2Provider_NewAuthorizeRequest {
-	c := _m.On("NewAuthorizeRequest", ctx, req)
-	return &OAuth2Provider_NewAuthorizeRequest{Call: c}
+	c_call := _m.On("NewAuthorizeRequest", ctx, req)
+	return &OAuth2Provider_NewAuthorizeRequest{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewAuthorizeRequestMatch(matchers ...interface{}) *OAuth2Provider_NewAuthorizeRequest {
-	c := _m.On("NewAuthorizeRequest", matchers...)
-	return &OAuth2Provider_NewAuthorizeRequest{Call: c}
+	c_call := _m.On("NewAuthorizeRequest", matchers...)
+	return &OAuth2Provider_NewAuthorizeRequest{Call: c_call}
 }
 
 // NewAuthorizeRequest provides a mock function with given fields: ctx, req
@@ -246,13 +246,13 @@ func (_m OAuth2Provider_NewAuthorizeResponse) Return(_a0 fosite.AuthorizeRespond
 }
 
 func (_m *OAuth2Provider) OnNewAuthorizeResponse(ctx context.Context, requester fosite.AuthorizeRequester, session fosite.Session) *OAuth2Provider_NewAuthorizeResponse {
-	c := _m.On("NewAuthorizeResponse", ctx, requester, session)
-	return &OAuth2Provider_NewAuthorizeResponse{Call: c}
+	c_call := _m.On("NewAuthorizeResponse", ctx, requester, session)
+	return &OAuth2Provider_NewAuthorizeResponse{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewAuthorizeResponseMatch(matchers ...interface{}) *OAuth2Provider_NewAuthorizeResponse {
-	c := _m.On("NewAuthorizeResponse", matchers...)
-	return &OAuth2Provider_NewAuthorizeResponse{Call: c}
+	c_call := _m.On("NewAuthorizeResponse", matchers...)
+	return &OAuth2Provider_NewAuthorizeResponse{Call: c_call}
 }
 
 // NewAuthorizeResponse provides a mock function with given fields: ctx, requester, session
@@ -287,13 +287,13 @@ func (_m OAuth2Provider_NewIntrospectionRequest) Return(_a0 fosite.Introspection
 }
 
 func (_m *OAuth2Provider) OnNewIntrospectionRequest(ctx context.Context, r *http.Request, session fosite.Session) *OAuth2Provider_NewIntrospectionRequest {
-	c := _m.On("NewIntrospectionRequest", ctx, r, session)
-	return &OAuth2Provider_NewIntrospectionRequest{Call: c}
+	c_call := _m.On("NewIntrospectionRequest", ctx, r, session)
+	return &OAuth2Provider_NewIntrospectionRequest{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewIntrospectionRequestMatch(matchers ...interface{}) *OAuth2Provider_NewIntrospectionRequest {
-	c := _m.On("NewIntrospectionRequest", matchers...)
-	return &OAuth2Provider_NewIntrospectionRequest{Call: c}
+	c_call := _m.On("NewIntrospectionRequest", matchers...)
+	return &OAuth2Provider_NewIntrospectionRequest{Call: c_call}
 }
 
 // NewIntrospectionRequest provides a mock function with given fields: ctx, r, session
@@ -328,13 +328,13 @@ func (_m OAuth2Provider_NewJWTSessionToken) Return(_a0 *oauth2.JWTSession) *OAut
 }
 
 func (_m *OAuth2Provider) OnNewJWTSessionToken(subject string, appID string, issuer string, audience string, userInfoClaims *service.UserInfoResponse) *OAuth2Provider_NewJWTSessionToken {
-	c := _m.On("NewJWTSessionToken", subject, appID, issuer, audience, userInfoClaims)
-	return &OAuth2Provider_NewJWTSessionToken{Call: c}
+	c_call := _m.On("NewJWTSessionToken", subject, appID, issuer, audience, userInfoClaims)
+	return &OAuth2Provider_NewJWTSessionToken{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewJWTSessionTokenMatch(matchers ...interface{}) *OAuth2Provider_NewJWTSessionToken {
-	c := _m.On("NewJWTSessionToken", matchers...)
-	return &OAuth2Provider_NewJWTSessionToken{Call: c}
+	c_call := _m.On("NewJWTSessionToken", matchers...)
+	return &OAuth2Provider_NewJWTSessionToken{Call: c_call}
 }
 
 // NewJWTSessionToken provides a mock function with given fields: subject, appID, issuer, audience, userInfoClaims
@@ -362,13 +362,13 @@ func (_m OAuth2Provider_NewRevocationRequest) Return(_a0 error) *OAuth2Provider_
 }
 
 func (_m *OAuth2Provider) OnNewRevocationRequest(ctx context.Context, r *http.Request) *OAuth2Provider_NewRevocationRequest {
-	c := _m.On("NewRevocationRequest", ctx, r)
-	return &OAuth2Provider_NewRevocationRequest{Call: c}
+	c_call := _m.On("NewRevocationRequest", ctx, r)
+	return &OAuth2Provider_NewRevocationRequest{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnNewRevocationRequestMatch(matchers ...interface{}) *OAuth2Provider_NewRevocationRequest {
-	c := _m.On("NewRevocationRequest", matchers...)
-	return &OAuth2Provider_NewRevocationRequest{Call: c}
+	c_call := _m.On("NewRevocationRequest", matchers...)
+	return &OAuth2Provider_NewRevocationRequest{Call: c_call}
 }
 
 // NewRevocationRequest provides a mock function with given fields: ctx, r
@@ -394,13 +394,13 @@ func (_m OAuth2Provider_ValidateAccessToken) Return(_a0 interfaces.IdentityConte
 }
 
 func (_m *OAuth2Provider) OnValidateAccessToken(ctx context.Context, expectedAudience string, tokenStr string) *OAuth2Provider_ValidateAccessToken {
-	c := _m.On("ValidateAccessToken", ctx, expectedAudience, tokenStr)
-	return &OAuth2Provider_ValidateAccessToken{Call: c}
+	c_call := _m.On("ValidateAccessToken", ctx, expectedAudience, tokenStr)
+	return &OAuth2Provider_ValidateAccessToken{Call: c_call}
 }
 
 func (_m *OAuth2Provider) OnValidateAccessTokenMatch(matchers ...interface{}) *OAuth2Provider_ValidateAccessToken {
-	c := _m.On("ValidateAccessToken", matchers...)
-	return &OAuth2Provider_ValidateAccessToken{Call: c}
+	c_call := _m.On("ValidateAccessToken", matchers...)
+	return &OAuth2Provider_ValidateAccessToken{Call: c_call}
 }
 
 // ValidateAccessToken provides a mock function with given fields: ctx, expectedAudience, tokenStr

--- a/auth/interfaces/mocks/o_auth2_resource_server.go
+++ b/auth/interfaces/mocks/o_auth2_resource_server.go
@@ -23,13 +23,13 @@ func (_m OAuth2ResourceServer_ValidateAccessToken) Return(_a0 interfaces.Identit
 }
 
 func (_m *OAuth2ResourceServer) OnValidateAccessToken(ctx context.Context, expectedAudience string, tokenStr string) *OAuth2ResourceServer_ValidateAccessToken {
-	c := _m.On("ValidateAccessToken", ctx, expectedAudience, tokenStr)
-	return &OAuth2ResourceServer_ValidateAccessToken{Call: c}
+	c_call := _m.On("ValidateAccessToken", ctx, expectedAudience, tokenStr)
+	return &OAuth2ResourceServer_ValidateAccessToken{Call: c_call}
 }
 
 func (_m *OAuth2ResourceServer) OnValidateAccessTokenMatch(matchers ...interface{}) *OAuth2ResourceServer_ValidateAccessToken {
-	c := _m.On("ValidateAccessToken", matchers...)
-	return &OAuth2ResourceServer_ValidateAccessToken{Call: c}
+	c_call := _m.On("ValidateAccessToken", matchers...)
+	return &OAuth2ResourceServer_ValidateAccessToken{Call: c_call}
 }
 
 // ValidateAccessToken provides a mock function with given fields: ctx, expectedAudience, tokenStr

--- a/boilerplate/flyte/end2end/end2end.sh
+++ b/boilerplate/flyte/end2end/end2end.sh
@@ -13,4 +13,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
-FLYTE_SDK_USE_STRUCTURED_DATASET=TRUE python ./boilerplate/flyte/end2end/run-tests.py $LATEST_VERSION P0,P1 $CONFIG_FILE ${EXTRA_FLAGS[@]}
+python ./boilerplate/flyte/end2end/run-tests.py $LATEST_VERSION P0,P1 $CONFIG_FILE ${EXTRA_FLAGS[@]}

--- a/boilerplate/flyte/golang_support_tools/go.mod
+++ b/boilerplate/flyte/golang_support_tools/go.mod
@@ -3,11 +3,11 @@ module github.com/flyteorg/boilerplate
 go 1.17
 
 require (
+	github.com/EngHabu/mockery v0.0.0-20220405200825-3f76291311cf
 	github.com/alvaroloes/enumer v1.1.2
 	github.com/flyteorg/flytestdlib v0.4.16
 	github.com/golangci/golangci-lint v1.38.0
 	github.com/pseudomuto/protoc-gen-doc v1.4.1
-	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5
 )
 
 require (
@@ -152,7 +152,7 @@ require (
 	github.com/spf13/viper v1.7.1 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b // indirect
 	github.com/tetafro/godot v1.4.4 // indirect
@@ -190,7 +190,5 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20210104141923-aac4ce9116a7 // indirect
 )
-
-replace github.com/vektra/mockery => github.com/enghabu/mockery v0.0.0-20191009061720-9d0c8670c2f0
 
 replace github.com/pseudomuto/protoc-gen-doc => github.com/flyteorg/protoc-gen-doc v1.4.2

--- a/boilerplate/flyte/golang_support_tools/go.sum
+++ b/boilerplate/flyte/golang_support_tools/go.sum
@@ -79,6 +79,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
+github.com/EngHabu/mockery v0.0.0-20220405200825-3f76291311cf h1:M7A2Tn3R8rVgsoJHHKkmkpiNOItys4GxJj6JytRjdDg=
+github.com/EngHabu/mockery v0.0.0-20220405200825-3f76291311cf/go.mod h1:Kya4Y46gyq/3TEyAzeNe5UkCk+W9apy5KbuX+5KnZ6M=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -194,8 +196,6 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/enghabu/mockery v0.0.0-20191009061720-9d0c8670c2f0 h1:qxIJwfSemSCqhG3/lEw1Rm+wYbegjuKsqy0ZqnIpL14=
-github.com/enghabu/mockery v0.0.0-20191009061720-9d0c8670c2f0/go.mod h1:KfdIkmkpVY3n2sc1ykFj01uMviOiXH2HMhUCvA5FYGg=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -773,8 +773,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhFAz3nWUcuvpH7WuOMv8LQoCWmruLfFH2U=
@@ -1035,7 +1036,6 @@ golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190110163146-51295c7ec13a/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/boilerplate/flyte/golang_support_tools/tools.go
+++ b/boilerplate/flyte/golang_support_tools/tools.go
@@ -1,11 +1,12 @@
+//go:build tools
 // +build tools
 
 package tools
 
 import (
+	_ "github.com/EngHabu/mockery/cmd/mockery"
 	_ "github.com/alvaroloes/enumer"
 	_ "github.com/flyteorg/flytestdlib/cli/pflags"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/vektra/mockery/cmd/mockery"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 )

--- a/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -16,8 +16,8 @@ set -e
 # List of tools to go get
 # In the format of "<cli>:<package>" or ":<package>" if no cli
 tools=(
-  "github.com/vektra/mockery/cmd/mockery"
-  "github.com/flyteorg/flytestdlib/cli/pflags"
+  "github.com/EngHabu/mockery/cmd/mockery"
+  "github.com/flyteorg/flytestdlib/cli/pflags@latest"
   "github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
   "github.com/alvaroloes/enumer"
   "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"

--- a/pkg/async/cloudevent/mocks/publisher.go
+++ b/pkg/async/cloudevent/mocks/publisher.go
@@ -24,13 +24,13 @@ func (_m Publisher_Publish) Return(_a0 error) *Publisher_Publish {
 }
 
 func (_m *Publisher) OnPublish(ctx context.Context, notificationType string, msg protoiface.MessageV1) *Publisher_Publish {
-	c := _m.On("Publish", ctx, notificationType, msg)
-	return &Publisher_Publish{Call: c}
+	c_call := _m.On("Publish", ctx, notificationType, msg)
+	return &Publisher_Publish{Call: c_call}
 }
 
 func (_m *Publisher) OnPublishMatch(matchers ...interface{}) *Publisher_Publish {
-	c := _m.On("Publish", matchers...)
-	return &Publisher_Publish{Call: c}
+	c_call := _m.On("Publish", matchers...)
+	return &Publisher_Publish{Call: c_call}
 }
 
 // Publish provides a mock function with given fields: ctx, notificationType, msg

--- a/pkg/async/cloudevent/mocks/sender.go
+++ b/pkg/async/cloudevent/mocks/sender.go
@@ -24,13 +24,13 @@ func (_m Sender_Send) Return(_a0 error) *Sender_Send {
 }
 
 func (_m *Sender) OnSend(ctx context.Context, notificationType string, _a2 event.Event) *Sender_Send {
-	c := _m.On("Send", ctx, notificationType, _a2)
-	return &Sender_Send{Call: c}
+	c_call := _m.On("Send", ctx, notificationType, _a2)
+	return &Sender_Send{Call: c_call}
 }
 
 func (_m *Sender) OnSendMatch(matchers ...interface{}) *Sender_Send {
-	c := _m.On("Send", matchers...)
-	return &Sender_Send{Call: c}
+	c_call := _m.On("Send", matchers...)
+	return &Sender_Send{Call: c_call}
 }
 
 // Send provides a mock function with given fields: ctx, notificationType, _a2

--- a/pkg/clusterresource/mocks/flyte_admin_data_provider.go
+++ b/pkg/clusterresource/mocks/flyte_admin_data_provider.go
@@ -24,13 +24,13 @@ func (_m FlyteAdminDataProvider_GetClusterResourceAttributes) Return(_a0 *admin.
 }
 
 func (_m *FlyteAdminDataProvider) OnGetClusterResourceAttributes(ctx context.Context, project string, domain string) *FlyteAdminDataProvider_GetClusterResourceAttributes {
-	c := _m.On("GetClusterResourceAttributes", ctx, project, domain)
-	return &FlyteAdminDataProvider_GetClusterResourceAttributes{Call: c}
+	c_call := _m.On("GetClusterResourceAttributes", ctx, project, domain)
+	return &FlyteAdminDataProvider_GetClusterResourceAttributes{Call: c_call}
 }
 
 func (_m *FlyteAdminDataProvider) OnGetClusterResourceAttributesMatch(matchers ...interface{}) *FlyteAdminDataProvider_GetClusterResourceAttributes {
-	c := _m.On("GetClusterResourceAttributes", matchers...)
-	return &FlyteAdminDataProvider_GetClusterResourceAttributes{Call: c}
+	c_call := _m.On("GetClusterResourceAttributes", matchers...)
+	return &FlyteAdminDataProvider_GetClusterResourceAttributes{Call: c_call}
 }
 
 // GetClusterResourceAttributes provides a mock function with given fields: ctx, project, domain
@@ -65,13 +65,13 @@ func (_m FlyteAdminDataProvider_GetProjects) Return(_a0 *admin.Projects, _a1 err
 }
 
 func (_m *FlyteAdminDataProvider) OnGetProjects(ctx context.Context) *FlyteAdminDataProvider_GetProjects {
-	c := _m.On("GetProjects", ctx)
-	return &FlyteAdminDataProvider_GetProjects{Call: c}
+	c_call := _m.On("GetProjects", ctx)
+	return &FlyteAdminDataProvider_GetProjects{Call: c_call}
 }
 
 func (_m *FlyteAdminDataProvider) OnGetProjectsMatch(matchers ...interface{}) *FlyteAdminDataProvider_GetProjects {
-	c := _m.On("GetProjects", matchers...)
-	return &FlyteAdminDataProvider_GetProjects{Call: c}
+	c_call := _m.On("GetProjects", matchers...)
+	return &FlyteAdminDataProvider_GetProjects{Call: c_call}
 }
 
 // GetProjects provides a mock function with given fields: ctx

--- a/pkg/executioncluster/mocks/cluster_interface.go
+++ b/pkg/executioncluster/mocks/cluster_interface.go
@@ -24,13 +24,13 @@ func (_m ClusterInterface_GetAllTargets) Return(_a0 map[string]*executioncluster
 }
 
 func (_m *ClusterInterface) OnGetAllTargets() *ClusterInterface_GetAllTargets {
-	c := _m.On("GetAllTargets")
-	return &ClusterInterface_GetAllTargets{Call: c}
+	c_call := _m.On("GetAllTargets")
+	return &ClusterInterface_GetAllTargets{Call: c_call}
 }
 
 func (_m *ClusterInterface) OnGetAllTargetsMatch(matchers ...interface{}) *ClusterInterface_GetAllTargets {
-	c := _m.On("GetAllTargets", matchers...)
-	return &ClusterInterface_GetAllTargets{Call: c}
+	c_call := _m.On("GetAllTargets", matchers...)
+	return &ClusterInterface_GetAllTargets{Call: c_call}
 }
 
 // GetAllTargets provides a mock function with given fields:
@@ -58,13 +58,13 @@ func (_m ClusterInterface_GetTarget) Return(_a0 *executioncluster.ExecutionTarge
 }
 
 func (_m *ClusterInterface) OnGetTarget(_a0 context.Context, _a1 *executioncluster.ExecutionTargetSpec) *ClusterInterface_GetTarget {
-	c := _m.On("GetTarget", _a0, _a1)
-	return &ClusterInterface_GetTarget{Call: c}
+	c_call := _m.On("GetTarget", _a0, _a1)
+	return &ClusterInterface_GetTarget{Call: c_call}
 }
 
 func (_m *ClusterInterface) OnGetTargetMatch(matchers ...interface{}) *ClusterInterface_GetTarget {
-	c := _m.On("GetTarget", matchers...)
-	return &ClusterInterface_GetTarget{Call: c}
+	c_call := _m.On("GetTarget", matchers...)
+	return &ClusterInterface_GetTarget{Call: c_call}
 }
 
 // GetTarget provides a mock function with given fields: _a0, _a1
@@ -99,13 +99,13 @@ func (_m ClusterInterface_GetValidTargets) Return(_a0 map[string]*executionclust
 }
 
 func (_m *ClusterInterface) OnGetValidTargets() *ClusterInterface_GetValidTargets {
-	c := _m.On("GetValidTargets")
-	return &ClusterInterface_GetValidTargets{Call: c}
+	c_call := _m.On("GetValidTargets")
+	return &ClusterInterface_GetValidTargets{Call: c_call}
 }
 
 func (_m *ClusterInterface) OnGetValidTargetsMatch(matchers ...interface{}) *ClusterInterface_GetValidTargets {
-	c := _m.On("GetValidTargets", matchers...)
-	return &ClusterInterface_GetValidTargets{Call: c}
+	c_call := _m.On("GetValidTargets", matchers...)
+	return &ClusterInterface_GetValidTargets{Call: c_call}
 }
 
 // GetValidTargets provides a mock function with given fields:

--- a/pkg/executioncluster/mocks/execution_target_provider.go
+++ b/pkg/executioncluster/mocks/execution_target_provider.go
@@ -26,13 +26,13 @@ func (_m ExecutionTargetProvider_GetExecutionTarget) Return(_a0 *executioncluste
 }
 
 func (_m *ExecutionTargetProvider) OnGetExecutionTarget(initializationErrorCounter prometheus.Counter, k8sCluster interfaces.ClusterConfig) *ExecutionTargetProvider_GetExecutionTarget {
-	c := _m.On("GetExecutionTarget", initializationErrorCounter, k8sCluster)
-	return &ExecutionTargetProvider_GetExecutionTarget{Call: c}
+	c_call := _m.On("GetExecutionTarget", initializationErrorCounter, k8sCluster)
+	return &ExecutionTargetProvider_GetExecutionTarget{Call: c_call}
 }
 
 func (_m *ExecutionTargetProvider) OnGetExecutionTargetMatch(matchers ...interface{}) *ExecutionTargetProvider_GetExecutionTarget {
-	c := _m.On("GetExecutionTarget", matchers...)
-	return &ExecutionTargetProvider_GetExecutionTarget{Call: c}
+	c_call := _m.On("GetExecutionTarget", matchers...)
+	return &ExecutionTargetProvider_GetExecutionTarget{Call: c_call}
 }
 
 // GetExecutionTarget provides a mock function with given fields: initializationErrorCounter, k8sCluster

--- a/pkg/executioncluster/mocks/get_target_interface.go
+++ b/pkg/executioncluster/mocks/get_target_interface.go
@@ -24,13 +24,13 @@ func (_m GetTargetInterface_GetTarget) Return(_a0 *executioncluster.ExecutionTar
 }
 
 func (_m *GetTargetInterface) OnGetTarget(_a0 context.Context, _a1 *executioncluster.ExecutionTargetSpec) *GetTargetInterface_GetTarget {
-	c := _m.On("GetTarget", _a0, _a1)
-	return &GetTargetInterface_GetTarget{Call: c}
+	c_call := _m.On("GetTarget", _a0, _a1)
+	return &GetTargetInterface_GetTarget{Call: c_call}
 }
 
 func (_m *GetTargetInterface) OnGetTargetMatch(matchers ...interface{}) *GetTargetInterface_GetTarget {
-	c := _m.On("GetTarget", matchers...)
-	return &GetTargetInterface_GetTarget{Call: c}
+	c_call := _m.On("GetTarget", matchers...)
+	return &GetTargetInterface_GetTarget{Call: c_call}
 }
 
 // GetTarget provides a mock function with given fields: _a0, _a1

--- a/pkg/executioncluster/mocks/list_targets_interface.go
+++ b/pkg/executioncluster/mocks/list_targets_interface.go
@@ -22,13 +22,13 @@ func (_m ListTargetsInterface_GetAllTargets) Return(_a0 map[string]*executionclu
 }
 
 func (_m *ListTargetsInterface) OnGetAllTargets() *ListTargetsInterface_GetAllTargets {
-	c := _m.On("GetAllTargets")
-	return &ListTargetsInterface_GetAllTargets{Call: c}
+	c_call := _m.On("GetAllTargets")
+	return &ListTargetsInterface_GetAllTargets{Call: c_call}
 }
 
 func (_m *ListTargetsInterface) OnGetAllTargetsMatch(matchers ...interface{}) *ListTargetsInterface_GetAllTargets {
-	c := _m.On("GetAllTargets", matchers...)
-	return &ListTargetsInterface_GetAllTargets{Call: c}
+	c_call := _m.On("GetAllTargets", matchers...)
+	return &ListTargetsInterface_GetAllTargets{Call: c_call}
 }
 
 // GetAllTargets provides a mock function with given fields:
@@ -56,13 +56,13 @@ func (_m ListTargetsInterface_GetValidTargets) Return(_a0 map[string]*executionc
 }
 
 func (_m *ListTargetsInterface) OnGetValidTargets() *ListTargetsInterface_GetValidTargets {
-	c := _m.On("GetValidTargets")
-	return &ListTargetsInterface_GetValidTargets{Call: c}
+	c_call := _m.On("GetValidTargets")
+	return &ListTargetsInterface_GetValidTargets{Call: c_call}
 }
 
 func (_m *ListTargetsInterface) OnGetValidTargetsMatch(matchers ...interface{}) *ListTargetsInterface_GetValidTargets {
-	c := _m.On("GetValidTargets", matchers...)
-	return &ListTargetsInterface_GetValidTargets{Call: c}
+	c_call := _m.On("GetValidTargets", matchers...)
+	return &ListTargetsInterface_GetValidTargets{Call: c_call}
 }
 
 // GetValidTargets provides a mock function with given fields:

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -496,6 +496,7 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 	workflowExecConfig := &admin.WorkflowExecutionConfig{}
 	// merge the request spec into workflowExecConfig
 	if isChanged := mergeIntoExecConfig(workflowExecConfig, request.Spec); isChanged {
+		logger.Infof(ctx, "getting the workflow execution config from request spec")
 		return workflowExecConfig, nil
 	}
 
@@ -503,6 +504,7 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 	if launchPlan != nil && launchPlan.Spec != nil {
 		// merge the launch plan spec into workflowExecConfig
 		if isChanged := mergeIntoExecConfig(workflowExecConfig, launchPlan.Spec); isChanged {
+			logger.Infof(ctx, "getting the workflow execution config from launchplan spec")
 			return workflowExecConfig, nil
 		}
 		if launchPlan.Spec.WorkflowId != nil {
@@ -520,11 +522,13 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 		// merge the matchable resource workflow execution config into workflowExecConfig
 		if isChanged := mergeIntoExecConfig(workflowExecConfig,
 			matchableResource.Attributes.GetWorkflowExecutionConfig()); isChanged {
+			logger.Infof(ctx, "getting the workflow execution config from workflow execution matchable attribute")
 			return workflowExecConfig, nil
 		}
 	}
 	//  merge the application config into workflowExecConfig
 	mergeIntoExecConfig(workflowExecConfig, m.config.ApplicationConfiguration().GetTopLevelConfig())
+	logger.Infof(ctx, "getting the workflow execution config from application configuration")
 	// Defaults to one from the application config
 	return workflowExecConfig, nil
 }
@@ -667,15 +671,12 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		return nil, nil, err
 	}
 
-	resolvedAuthRole := resolveAuthRole(request, launchPlan)
-	resolvedSecurityCtx := resolveSecurityCtx(ctx, request, launchPlan, resolvedAuthRole)
 	executionParameters := workflowengineInterfaces.ExecutionParameters{
 		Inputs:              request.Inputs,
 		AcceptedAt:          requestedAt,
 		Labels:              labels,
 		Annotations:         annotations,
 		ExecutionConfig:     executionConfig,
-		SecurityContext:     resolvedSecurityCtx,
 		TaskResources:       &platformTaskResources,
 		EventVersion:        m.config.ApplicationConfiguration().GetTopLevelConfig().EventVersion,
 		RoleNameKey:         m.config.ApplicationConfiguration().GetTopLevelConfig().RoleNameKey,
@@ -907,15 +908,12 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		return nil, nil, err
 	}
 
-	resolvedAuthRole := resolveAuthRole(request, launchPlan)
-	resolvedSecurityCtx := resolveSecurityCtx(ctx, request, launchPlan, resolvedAuthRole)
 	executionParameters := workflowengineInterfaces.ExecutionParameters{
 		Inputs:              executionInputs,
 		AcceptedAt:          requestedAt,
 		Labels:              labels,
 		Annotations:         annotations,
 		ExecutionConfig:     executionConfig,
-		SecurityContext:     resolvedSecurityCtx,
 		TaskResources:       &platformTaskResources,
 		EventVersion:        m.config.ApplicationConfiguration().GetTopLevelConfig().EventVersion,
 		RoleNameKey:         m.config.ApplicationConfiguration().GetTopLevelConfig().RoleNameKey,

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -744,7 +744,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		Cluster:               execInfo.Cluster,
 		InputsURI:             inputsURI,
 		UserInputsURI:         userInputsURI,
-		SecurityContext:       resolvedSecurityCtx,
+		SecurityContext:       executionConfig.GetSecurityContext(),
 	})
 	if err != nil {
 		logger.Infof(ctx, "Failed to create execution model in transformer for id: [%+v] with err: %v",
@@ -982,7 +982,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		Cluster:               execInfo.Cluster,
 		InputsURI:             inputsURI,
 		UserInputsURI:         userInputsURI,
-		SecurityContext:       resolvedSecurityCtx,
+		SecurityContext:       executionConfig.GetSecurityContext(),
 	})
 	if err != nil {
 		logger.Infof(ctx, "Failed to create execution model in transformer for id: [%+v] with err: %v",

--- a/pkg/manager/mocks/version_interface.go
+++ b/pkg/manager/mocks/version_interface.go
@@ -24,13 +24,13 @@ func (_m VersionInterface_GetVersion) Return(_a0 *admin.GetVersionResponse, _a1 
 }
 
 func (_m *VersionInterface) OnGetVersion(ctx context.Context, r *admin.GetVersionRequest) *VersionInterface_GetVersion {
-	c := _m.On("GetVersion", ctx, r)
-	return &VersionInterface_GetVersion{Call: c}
+	c_call := _m.On("GetVersion", ctx, r)
+	return &VersionInterface_GetVersion{Call: c_call}
 }
 
 func (_m *VersionInterface) OnGetVersionMatch(matchers ...interface{}) *VersionInterface_GetVersion {
-	c := _m.On("GetVersion", matchers...)
-	return &VersionInterface_GetVersion{Call: c}
+	c_call := _m.On("GetVersion", matchers...)
+	return &VersionInterface_GetVersion{Call: c_call}
 }
 
 // GetVersion provides a mock function with given fields: ctx, r

--- a/pkg/repositories/mocks/execution_event_repo_interface.go
+++ b/pkg/repositories/mocks/execution_event_repo_interface.go
@@ -24,13 +24,13 @@ func (_m ExecutionEventRepoInterface_Create) Return(_a0 error) *ExecutionEventRe
 }
 
 func (_m *ExecutionEventRepoInterface) OnCreate(ctx context.Context, input models.ExecutionEvent) *ExecutionEventRepoInterface_Create {
-	c := _m.On("Create", ctx, input)
-	return &ExecutionEventRepoInterface_Create{Call: c}
+	c_call := _m.On("Create", ctx, input)
+	return &ExecutionEventRepoInterface_Create{Call: c_call}
 }
 
 func (_m *ExecutionEventRepoInterface) OnCreateMatch(matchers ...interface{}) *ExecutionEventRepoInterface_Create {
-	c := _m.On("Create", matchers...)
-	return &ExecutionEventRepoInterface_Create{Call: c}
+	c_call := _m.On("Create", matchers...)
+	return &ExecutionEventRepoInterface_Create{Call: c_call}
 }
 
 // Create provides a mock function with given fields: ctx, input

--- a/pkg/repositories/mocks/node_execution_event_repo_interface.go
+++ b/pkg/repositories/mocks/node_execution_event_repo_interface.go
@@ -24,13 +24,13 @@ func (_m NodeExecutionEventRepoInterface_Create) Return(_a0 error) *NodeExecutio
 }
 
 func (_m *NodeExecutionEventRepoInterface) OnCreate(ctx context.Context, input models.NodeExecutionEvent) *NodeExecutionEventRepoInterface_Create {
-	c := _m.On("Create", ctx, input)
-	return &NodeExecutionEventRepoInterface_Create{Call: c}
+	c_call := _m.On("Create", ctx, input)
+	return &NodeExecutionEventRepoInterface_Create{Call: c_call}
 }
 
 func (_m *NodeExecutionEventRepoInterface) OnCreateMatch(matchers ...interface{}) *NodeExecutionEventRepoInterface_Create {
-	c := _m.On("Create", matchers...)
-	return &NodeExecutionEventRepoInterface_Create{Call: c}
+	c_call := _m.On("Create", matchers...)
+	return &NodeExecutionEventRepoInterface_Create{Call: c_call}
 }
 
 // Create provides a mock function with given fields: ctx, input

--- a/pkg/runtime/interfaces/mocks/quality_of_service_configuration.go
+++ b/pkg/runtime/interfaces/mocks/quality_of_service_configuration.go
@@ -22,13 +22,13 @@ func (_m QualityOfServiceConfiguration_GetDefaultTiers) Return(_a0 map[string]co
 }
 
 func (_m *QualityOfServiceConfiguration) OnGetDefaultTiers() *QualityOfServiceConfiguration_GetDefaultTiers {
-	c := _m.On("GetDefaultTiers")
-	return &QualityOfServiceConfiguration_GetDefaultTiers{Call: c}
+	c_call := _m.On("GetDefaultTiers")
+	return &QualityOfServiceConfiguration_GetDefaultTiers{Call: c_call}
 }
 
 func (_m *QualityOfServiceConfiguration) OnGetDefaultTiersMatch(matchers ...interface{}) *QualityOfServiceConfiguration_GetDefaultTiers {
-	c := _m.On("GetDefaultTiers", matchers...)
-	return &QualityOfServiceConfiguration_GetDefaultTiers{Call: c}
+	c_call := _m.On("GetDefaultTiers", matchers...)
+	return &QualityOfServiceConfiguration_GetDefaultTiers{Call: c_call}
 }
 
 // GetDefaultTiers provides a mock function with given fields:
@@ -56,13 +56,13 @@ func (_m QualityOfServiceConfiguration_GetTierExecutionValues) Return(_a0 map[co
 }
 
 func (_m *QualityOfServiceConfiguration) OnGetTierExecutionValues() *QualityOfServiceConfiguration_GetTierExecutionValues {
-	c := _m.On("GetTierExecutionValues")
-	return &QualityOfServiceConfiguration_GetTierExecutionValues{Call: c}
+	c_call := _m.On("GetTierExecutionValues")
+	return &QualityOfServiceConfiguration_GetTierExecutionValues{Call: c_call}
 }
 
 func (_m *QualityOfServiceConfiguration) OnGetTierExecutionValuesMatch(matchers ...interface{}) *QualityOfServiceConfiguration_GetTierExecutionValues {
-	c := _m.On("GetTierExecutionValues", matchers...)
-	return &QualityOfServiceConfiguration_GetTierExecutionValues{Call: c}
+	c_call := _m.On("GetTierExecutionValues", matchers...)
+	return &QualityOfServiceConfiguration_GetTierExecutionValues{Call: c_call}
 }
 
 // GetTierExecutionValues provides a mock function with given fields:

--- a/pkg/runtime/mocks/cluster_configuration.go
+++ b/pkg/runtime/mocks/cluster_configuration.go
@@ -21,13 +21,13 @@ func (_m ClusterConfiguration_GetClusterConfigs) Return(_a0 []interfaces.Cluster
 }
 
 func (_m *ClusterConfiguration) OnGetClusterConfigs() *ClusterConfiguration_GetClusterConfigs {
-	c := _m.On("GetClusterConfigs")
-	return &ClusterConfiguration_GetClusterConfigs{Call: c}
+	c_call := _m.On("GetClusterConfigs")
+	return &ClusterConfiguration_GetClusterConfigs{Call: c_call}
 }
 
 func (_m *ClusterConfiguration) OnGetClusterConfigsMatch(matchers ...interface{}) *ClusterConfiguration_GetClusterConfigs {
-	c := _m.On("GetClusterConfigs", matchers...)
-	return &ClusterConfiguration_GetClusterConfigs{Call: c}
+	c_call := _m.On("GetClusterConfigs", matchers...)
+	return &ClusterConfiguration_GetClusterConfigs{Call: c_call}
 }
 
 // GetClusterConfigs provides a mock function with given fields:
@@ -55,13 +55,13 @@ func (_m ClusterConfiguration_GetLabelClusterMap) Return(_a0 map[string][]interf
 }
 
 func (_m *ClusterConfiguration) OnGetLabelClusterMap() *ClusterConfiguration_GetLabelClusterMap {
-	c := _m.On("GetLabelClusterMap")
-	return &ClusterConfiguration_GetLabelClusterMap{Call: c}
+	c_call := _m.On("GetLabelClusterMap")
+	return &ClusterConfiguration_GetLabelClusterMap{Call: c_call}
 }
 
 func (_m *ClusterConfiguration) OnGetLabelClusterMapMatch(matchers ...interface{}) *ClusterConfiguration_GetLabelClusterMap {
-	c := _m.On("GetLabelClusterMap", matchers...)
-	return &ClusterConfiguration_GetLabelClusterMap{Call: c}
+	c_call := _m.On("GetLabelClusterMap", matchers...)
+	return &ClusterConfiguration_GetLabelClusterMap{Call: c_call}
 }
 
 // GetLabelClusterMap provides a mock function with given fields:

--- a/pkg/runtime/mocks/namespace_mapping_configuration.go
+++ b/pkg/runtime/mocks/namespace_mapping_configuration.go
@@ -18,13 +18,13 @@ func (_m NamespaceMappingConfiguration_GetNamespaceTemplate) Return(_a0 string) 
 }
 
 func (_m *NamespaceMappingConfiguration) OnGetNamespaceTemplate() *NamespaceMappingConfiguration_GetNamespaceTemplate {
-	c := _m.On("GetNamespaceTemplate")
-	return &NamespaceMappingConfiguration_GetNamespaceTemplate{Call: c}
+	c_call := _m.On("GetNamespaceTemplate")
+	return &NamespaceMappingConfiguration_GetNamespaceTemplate{Call: c_call}
 }
 
 func (_m *NamespaceMappingConfiguration) OnGetNamespaceTemplateMatch(matchers ...interface{}) *NamespaceMappingConfiguration_GetNamespaceTemplate {
-	c := _m.On("GetNamespaceTemplate", matchers...)
-	return &NamespaceMappingConfiguration_GetNamespaceTemplate{Call: c}
+	c_call := _m.On("GetNamespaceTemplate", matchers...)
+	return &NamespaceMappingConfiguration_GetNamespaceTemplate{Call: c_call}
 }
 
 // GetNamespaceTemplate provides a mock function with given fields:

--- a/pkg/workflowengine/impl/k8s_executor_test.go
+++ b/pkg/workflowengine/impl/k8s_executor_test.go
@@ -5,23 +5,23 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/flyteorg/flyteadmin/pkg/workflowengine/mocks"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/flyteorg/flyteadmin/pkg/workflowengine/interfaces"
-	"github.com/stretchr/testify/assert"
-	k8_api_err "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/flyteorg/flyteadmin/pkg/executioncluster"
 	execClusterIfaces "github.com/flyteorg/flyteadmin/pkg/executioncluster/interfaces"
 	clusterMock "github.com/flyteorg/flyteadmin/pkg/executioncluster/mocks"
+	"github.com/flyteorg/flyteadmin/pkg/workflowengine/interfaces"
+	"github.com/flyteorg/flyteadmin/pkg/workflowengine/mocks"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	flyteclient "github.com/flyteorg/flytepropeller/pkg/client/clientset/versioned"
 	v1alpha12 "github.com/flyteorg/flytepropeller/pkg/client/clientset/versioned/typed/flyteworkflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/mock"
+	k8_api_err "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var fakeFlyteWF = FakeFlyteWorkflowV1alpha1{}
@@ -165,6 +165,14 @@ func TestExecute(t *testing.T) {
 		WorkflowClosure:         &workflowClosure,
 		ExecutionParameters: interfaces.ExecutionParameters{
 			Inputs: testInputs,
+			ExecutionConfig: &admin.WorkflowExecutionConfig{
+				SecurityContext: &core.SecurityContext{
+					RunAs: &core.Identity{
+						IamRole:           testRoleSc,
+						K8SServiceAccount: testK8sServiceAccountSc,
+					},
+				},
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -192,6 +200,16 @@ func TestExecute_AlreadyExists(t *testing.T) {
 		ExecutionID:             execID,
 		ReferenceWorkflowName:   "ref_workflow_name",
 		ReferenceLaunchPlanName: "ref_lp_name",
+		ExecutionParameters: interfaces.ExecutionParameters{
+			ExecutionConfig: &admin.WorkflowExecutionConfig{
+				SecurityContext: &core.SecurityContext{
+					RunAs: &core.Identity{
+						IamRole:           testRoleSc,
+						K8SServiceAccount: testK8sServiceAccountSc,
+					},
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, resp.Cluster, clusterID)
@@ -218,6 +236,16 @@ func TestExecute_MiscError(t *testing.T) {
 		ExecutionID:             execID,
 		ReferenceWorkflowName:   "ref_workflow_name",
 		ReferenceLaunchPlanName: "ref_lp_name",
+		ExecutionParameters: interfaces.ExecutionParameters{
+			ExecutionConfig: &admin.WorkflowExecutionConfig{
+				SecurityContext: &core.SecurityContext{
+					RunAs: &core.Identity{
+						IamRole:           testRoleSc,
+						K8SServiceAccount: testK8sServiceAccountSc,
+					},
+				},
+			},
+		},
 	})
 	assert.EqualError(t, err, "failed to create workflow in propeller call failed")
 }

--- a/pkg/workflowengine/impl/prepare_execution.go
+++ b/pkg/workflowengine/impl/prepare_execution.go
@@ -117,7 +117,7 @@ func PrepareFlyteWorkflow(data interfaces.ExecutionData, flyteWorkflow *v1alpha1
 
 	// add permissions from auth and security context. Adding permissions from auth would be removed once all clients
 	// have migrated over to security context
-	addPermissions(data.ExecutionParameters.SecurityContext,
+	addPermissions(data.ExecutionParameters.ExecutionConfig.SecurityContext,
 		data.ExecutionParameters.RoleNameKey, flyteWorkflow)
 
 	labels := addMapValues(data.ExecutionParameters.Labels, flyteWorkflow.Labels)

--- a/pkg/workflowengine/impl/prepare_execution_test.go
+++ b/pkg/workflowengine/impl/prepare_execution_test.go
@@ -179,14 +179,14 @@ func TestPrepareFlyteWorkflow(t *testing.T) {
 					MissingPluginBehavior: admin.PluginOverride_USE_DEFAULT,
 				},
 			},
-			SecurityContext: &core.SecurityContext{
-				RunAs: &core.Identity{
-					IamRole:           testRoleSc,
-					K8SServiceAccount: testK8sServiceAccountSc,
-				},
-			},
 			ExecutionConfig: &admin.WorkflowExecutionConfig{
 				MaxParallelism: 50,
+				SecurityContext: &core.SecurityContext{
+					RunAs: &core.Identity{
+						IamRole:           testRoleSc,
+						K8SServiceAccount: testK8sServiceAccountSc,
+					},
+				},
 			},
 			RecoveryExecution: recoveryNodeExecutionID,
 			EventVersion:      1,

--- a/pkg/workflowengine/interfaces/executor.go
+++ b/pkg/workflowengine/interfaces/executor.go
@@ -24,7 +24,6 @@ type ExecutionParameters struct {
 	Annotations         map[string]string
 	TaskPluginOverrides []*admin.PluginOverride
 	ExecutionConfig     *admin.WorkflowExecutionConfig
-	SecurityContext     *core.SecurityContext
 	RecoveryExecution   *core.WorkflowExecutionIdentifier
 	TaskResources       *TaskResources
 	EventVersion        int

--- a/pkg/workflowengine/mocks/flyte_workflow_builder.go
+++ b/pkg/workflowengine/mocks/flyte_workflow_builder.go
@@ -24,13 +24,13 @@ func (_m FlyteWorkflowBuilder_Build) Return(_a0 *v1alpha1.FlyteWorkflow, _a1 err
 }
 
 func (_m *FlyteWorkflowBuilder) OnBuild(wfClosure *core.CompiledWorkflowClosure, inputs *core.LiteralMap, executionID *core.WorkflowExecutionIdentifier, namespace string) *FlyteWorkflowBuilder_Build {
-	c := _m.On("Build", wfClosure, inputs, executionID, namespace)
-	return &FlyteWorkflowBuilder_Build{Call: c}
+	c_call := _m.On("Build", wfClosure, inputs, executionID, namespace)
+	return &FlyteWorkflowBuilder_Build{Call: c_call}
 }
 
 func (_m *FlyteWorkflowBuilder) OnBuildMatch(matchers ...interface{}) *FlyteWorkflowBuilder_Build {
-	c := _m.On("Build", matchers...)
-	return &FlyteWorkflowBuilder_Build{Call: c}
+	c_call := _m.On("Build", matchers...)
+	return &FlyteWorkflowBuilder_Build{Call: c_call}
 }
 
 // Build provides a mock function with given fields: wfClosure, inputs, executionID, namespace

--- a/pkg/workflowengine/mocks/workflow_executor.go
+++ b/pkg/workflowengine/mocks/workflow_executor.go
@@ -23,13 +23,13 @@ func (_m WorkflowExecutor_Abort) Return(_a0 error) *WorkflowExecutor_Abort {
 }
 
 func (_m *WorkflowExecutor) OnAbort(ctx context.Context, data interfaces.AbortData) *WorkflowExecutor_Abort {
-	c := _m.On("Abort", ctx, data)
-	return &WorkflowExecutor_Abort{Call: c}
+	c_call := _m.On("Abort", ctx, data)
+	return &WorkflowExecutor_Abort{Call: c_call}
 }
 
 func (_m *WorkflowExecutor) OnAbortMatch(matchers ...interface{}) *WorkflowExecutor_Abort {
-	c := _m.On("Abort", matchers...)
-	return &WorkflowExecutor_Abort{Call: c}
+	c_call := _m.On("Abort", matchers...)
+	return &WorkflowExecutor_Abort{Call: c_call}
 }
 
 // Abort provides a mock function with given fields: ctx, data
@@ -55,13 +55,13 @@ func (_m WorkflowExecutor_Execute) Return(_a0 interfaces.ExecutionResponse, _a1 
 }
 
 func (_m *WorkflowExecutor) OnExecute(ctx context.Context, data interfaces.ExecutionData) *WorkflowExecutor_Execute {
-	c := _m.On("Execute", ctx, data)
-	return &WorkflowExecutor_Execute{Call: c}
+	c_call := _m.On("Execute", ctx, data)
+	return &WorkflowExecutor_Execute{Call: c_call}
 }
 
 func (_m *WorkflowExecutor) OnExecuteMatch(matchers ...interface{}) *WorkflowExecutor_Execute {
-	c := _m.On("Execute", matchers...)
-	return &WorkflowExecutor_Execute{Call: c}
+	c_call := _m.On("Execute", matchers...)
+	return &WorkflowExecutor_Execute{Call: c_call}
 }
 
 // Execute provides a mock function with given fields: ctx, data
@@ -94,13 +94,13 @@ func (_m WorkflowExecutor_ID) Return(_a0 string) *WorkflowExecutor_ID {
 }
 
 func (_m *WorkflowExecutor) OnID() *WorkflowExecutor_ID {
-	c := _m.On("ID")
-	return &WorkflowExecutor_ID{Call: c}
+	c_call := _m.On("ID")
+	return &WorkflowExecutor_ID{Call: c_call}
 }
 
 func (_m *WorkflowExecutor) OnIDMatch(matchers ...interface{}) *WorkflowExecutor_ID {
-	c := _m.On("ID", matchers...)
-	return &WorkflowExecutor_ID{Call: c}
+	c_call := _m.On("ID", matchers...)
+	return &WorkflowExecutor_ID{Call: c_call}
 }
 
 // ID provides a mock function with given fields:

--- a/scheduler/executor/mocks/executor.go
+++ b/scheduler/executor/mocks/executor.go
@@ -26,13 +26,13 @@ func (_m Executor_Execute) Return(_a0 error) *Executor_Execute {
 }
 
 func (_m *Executor) OnExecute(ctx context.Context, scheduledTime time.Time, s models.SchedulableEntity) *Executor_Execute {
-	c := _m.On("Execute", ctx, scheduledTime, s)
-	return &Executor_Execute{Call: c}
+	c_call := _m.On("Execute", ctx, scheduledTime, s)
+	return &Executor_Execute{Call: c_call}
 }
 
 func (_m *Executor) OnExecuteMatch(matchers ...interface{}) *Executor_Execute {
-	c := _m.On("Execute", matchers...)
-	return &Executor_Execute{Call: c}
+	c_call := _m.On("Execute", matchers...)
+	return &Executor_Execute{Call: c_call}
 }
 
 // Execute provides a mock function with given fields: ctx, scheduledTime, s

--- a/scheduler/repositories/mocks/schedulable_entity_repo_interface.go
+++ b/scheduler/repositories/mocks/schedulable_entity_repo_interface.go
@@ -24,13 +24,13 @@ func (_m SchedulableEntityRepoInterface_Activate) Return(_a0 error) *Schedulable
 }
 
 func (_m *SchedulableEntityRepoInterface) OnActivate(ctx context.Context, input models.SchedulableEntity) *SchedulableEntityRepoInterface_Activate {
-	c := _m.On("Activate", ctx, input)
-	return &SchedulableEntityRepoInterface_Activate{Call: c}
+	c_call := _m.On("Activate", ctx, input)
+	return &SchedulableEntityRepoInterface_Activate{Call: c_call}
 }
 
 func (_m *SchedulableEntityRepoInterface) OnActivateMatch(matchers ...interface{}) *SchedulableEntityRepoInterface_Activate {
-	c := _m.On("Activate", matchers...)
-	return &SchedulableEntityRepoInterface_Activate{Call: c}
+	c_call := _m.On("Activate", matchers...)
+	return &SchedulableEntityRepoInterface_Activate{Call: c_call}
 }
 
 // Activate provides a mock function with given fields: ctx, input
@@ -56,13 +56,13 @@ func (_m SchedulableEntityRepoInterface_Create) Return(_a0 error) *SchedulableEn
 }
 
 func (_m *SchedulableEntityRepoInterface) OnCreate(ctx context.Context, input models.SchedulableEntity) *SchedulableEntityRepoInterface_Create {
-	c := _m.On("Create", ctx, input)
-	return &SchedulableEntityRepoInterface_Create{Call: c}
+	c_call := _m.On("Create", ctx, input)
+	return &SchedulableEntityRepoInterface_Create{Call: c_call}
 }
 
 func (_m *SchedulableEntityRepoInterface) OnCreateMatch(matchers ...interface{}) *SchedulableEntityRepoInterface_Create {
-	c := _m.On("Create", matchers...)
-	return &SchedulableEntityRepoInterface_Create{Call: c}
+	c_call := _m.On("Create", matchers...)
+	return &SchedulableEntityRepoInterface_Create{Call: c_call}
 }
 
 // Create provides a mock function with given fields: ctx, input
@@ -88,13 +88,13 @@ func (_m SchedulableEntityRepoInterface_Deactivate) Return(_a0 error) *Schedulab
 }
 
 func (_m *SchedulableEntityRepoInterface) OnDeactivate(ctx context.Context, ID models.SchedulableEntityKey) *SchedulableEntityRepoInterface_Deactivate {
-	c := _m.On("Deactivate", ctx, ID)
-	return &SchedulableEntityRepoInterface_Deactivate{Call: c}
+	c_call := _m.On("Deactivate", ctx, ID)
+	return &SchedulableEntityRepoInterface_Deactivate{Call: c_call}
 }
 
 func (_m *SchedulableEntityRepoInterface) OnDeactivateMatch(matchers ...interface{}) *SchedulableEntityRepoInterface_Deactivate {
-	c := _m.On("Deactivate", matchers...)
-	return &SchedulableEntityRepoInterface_Deactivate{Call: c}
+	c_call := _m.On("Deactivate", matchers...)
+	return &SchedulableEntityRepoInterface_Deactivate{Call: c_call}
 }
 
 // Deactivate provides a mock function with given fields: ctx, ID
@@ -120,13 +120,13 @@ func (_m SchedulableEntityRepoInterface_Get) Return(_a0 models.SchedulableEntity
 }
 
 func (_m *SchedulableEntityRepoInterface) OnGet(ctx context.Context, ID models.SchedulableEntityKey) *SchedulableEntityRepoInterface_Get {
-	c := _m.On("Get", ctx, ID)
-	return &SchedulableEntityRepoInterface_Get{Call: c}
+	c_call := _m.On("Get", ctx, ID)
+	return &SchedulableEntityRepoInterface_Get{Call: c_call}
 }
 
 func (_m *SchedulableEntityRepoInterface) OnGetMatch(matchers ...interface{}) *SchedulableEntityRepoInterface_Get {
-	c := _m.On("Get", matchers...)
-	return &SchedulableEntityRepoInterface_Get{Call: c}
+	c_call := _m.On("Get", matchers...)
+	return &SchedulableEntityRepoInterface_Get{Call: c_call}
 }
 
 // Get provides a mock function with given fields: ctx, ID
@@ -159,13 +159,13 @@ func (_m SchedulableEntityRepoInterface_GetAll) Return(_a0 []models.SchedulableE
 }
 
 func (_m *SchedulableEntityRepoInterface) OnGetAll(ctx context.Context) *SchedulableEntityRepoInterface_GetAll {
-	c := _m.On("GetAll", ctx)
-	return &SchedulableEntityRepoInterface_GetAll{Call: c}
+	c_call := _m.On("GetAll", ctx)
+	return &SchedulableEntityRepoInterface_GetAll{Call: c_call}
 }
 
 func (_m *SchedulableEntityRepoInterface) OnGetAllMatch(matchers ...interface{}) *SchedulableEntityRepoInterface_GetAll {
-	c := _m.On("GetAll", matchers...)
-	return &SchedulableEntityRepoInterface_GetAll{Call: c}
+	c_call := _m.On("GetAll", matchers...)
+	return &SchedulableEntityRepoInterface_GetAll{Call: c_call}
 }
 
 // GetAll provides a mock function with given fields: ctx

--- a/scheduler/repositories/mocks/schedule_entities_snap_shot_repo_interface.go
+++ b/scheduler/repositories/mocks/schedule_entities_snap_shot_repo_interface.go
@@ -24,13 +24,13 @@ func (_m ScheduleEntitiesSnapShotRepoInterface_Read) Return(_a0 models.ScheduleE
 }
 
 func (_m *ScheduleEntitiesSnapShotRepoInterface) OnRead(ctx context.Context) *ScheduleEntitiesSnapShotRepoInterface_Read {
-	c := _m.On("Read", ctx)
-	return &ScheduleEntitiesSnapShotRepoInterface_Read{Call: c}
+	c_call := _m.On("Read", ctx)
+	return &ScheduleEntitiesSnapShotRepoInterface_Read{Call: c_call}
 }
 
 func (_m *ScheduleEntitiesSnapShotRepoInterface) OnReadMatch(matchers ...interface{}) *ScheduleEntitiesSnapShotRepoInterface_Read {
-	c := _m.On("Read", matchers...)
-	return &ScheduleEntitiesSnapShotRepoInterface_Read{Call: c}
+	c_call := _m.On("Read", matchers...)
+	return &ScheduleEntitiesSnapShotRepoInterface_Read{Call: c_call}
 }
 
 // Read provides a mock function with given fields: ctx
@@ -63,13 +63,13 @@ func (_m ScheduleEntitiesSnapShotRepoInterface_Write) Return(_a0 error) *Schedul
 }
 
 func (_m *ScheduleEntitiesSnapShotRepoInterface) OnWrite(ctx context.Context, input models.ScheduleEntitiesSnapshot) *ScheduleEntitiesSnapShotRepoInterface_Write {
-	c := _m.On("Write", ctx, input)
-	return &ScheduleEntitiesSnapShotRepoInterface_Write{Call: c}
+	c_call := _m.On("Write", ctx, input)
+	return &ScheduleEntitiesSnapShotRepoInterface_Write{Call: c_call}
 }
 
 func (_m *ScheduleEntitiesSnapShotRepoInterface) OnWriteMatch(matchers ...interface{}) *ScheduleEntitiesSnapShotRepoInterface_Write {
-	c := _m.On("Write", matchers...)
-	return &ScheduleEntitiesSnapShotRepoInterface_Write{Call: c}
+	c_call := _m.On("Write", matchers...)
+	return &ScheduleEntitiesSnapShotRepoInterface_Write{Call: c_call}
 }
 
 // Write provides a mock function with given fields: ctx, input


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Removed the resolved security context function and always use the security context from the execution parameters which go through the resolution from request, launchplan, matchable attribute and application configuration

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
