### PR TITLE
Propagate security ctx to flyte workflow CRD

### DIFF
--- a/pkg/workflowengine/impl/prepare_execution.go
+++ b/pkg/workflowengine/impl/prepare_execution.go
@@ -27,6 +27,7 @@ func addPermissions(securityCtx *core.SecurityContext, roleNameKey string, flyte
 	if securityCtx == nil || securityCtx.RunAs == nil {
 		return
 	}
+	flyteWf.SecurityContext = *securityCtx
 	if len(securityCtx.RunAs.IamRole) > 0 {
 		if flyteWf.Annotations == nil {
 			flyteWf.Annotations = map[string]string{}

--- a/pkg/workflowengine/impl/prepare_execution_test.go
+++ b/pkg/workflowengine/impl/prepare_execution_test.go
@@ -71,6 +71,7 @@ func TestAddPermissions(t *testing.T) {
 			roleNameKey: testRole,
 		})
 		assert.Equal(t, testK8sServiceAccount, flyteWf.ServiceAccountName)
+		assert.True(t, proto.Equal(&flyteWf.SecurityContext, securityCtxFromAuth))
 	})
 
 	t.Run("override using security ctx", func(t *testing.T) {
@@ -80,6 +81,7 @@ func TestAddPermissions(t *testing.T) {
 			roleNameKey: testRoleSc,
 		})
 		assert.Equal(t, testK8sServiceAccountSc, flyteWf.ServiceAccountName)
+		assert.True(t, proto.Equal(&flyteWf.SecurityContext, securityCtx))
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
In addition to setting the IAM role annotation or service account name on the flyte workflow CRD, we should also pass in the full security context so this can be propagated to child workflows.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
