### PR TITLE
Store job entry ID for fixed rate scheduler and also fixes cron schedule for missing key

### DIFF
--- a/scheduler/core/gocron_scheduler.go
+++ b/scheduler/core/gocron_scheduler.go
@@ -271,7 +271,9 @@ func (g *GoCronScheduler) AddFixedIntervalJob(ctx context.Context, job *GoCronJo
 	var jobFunc cron.TimedFuncJob
 	jobFunc = job.Run
 
-	g.cron.ScheduleTimedJob(cron.ConstantDelaySchedule{Delay: d}, jobFunc)
+	entryID := g.cron.ScheduleTimedJob(cron.ConstantDelaySchedule{Delay: d}, jobFunc)
+	// Update the enttry id in the job which is handle to be used for removal
+	job.entryID = entryID
 	logger.Infof(ctx, "successfully added the fixed rate schedule %s to the scheduler for schedule %+v",
 		job.nameOfSchedule, job.schedule)
 

--- a/scheduler/executor/executor_impl.go
+++ b/scheduler/executor/executor_impl.go
@@ -37,7 +37,7 @@ func (w *executor) Execute(ctx context.Context, scheduledTime time.Time, s model
 
 	literalsInputMap := map[string]*core.Literal{}
 	// Only add kickoff time input arg for cron based schedules
-	if len(s.CronExpression) > 0 {
+	if len(s.CronExpression) > 0 && len(s.KickoffTimeInputArg) > 0 {
 		literalsInputMap[s.KickoffTimeInputArg] = &core.Literal{
 			Value: &core.Literal_Scalar{
 				Scalar: &core.Scalar{

--- a/scheduler/executor/executor_impl_test.go
+++ b/scheduler/executor/executor_impl_test.go
@@ -28,20 +28,36 @@ func setupExecutor(scope string) Executor {
 func TestExecutor(t *testing.T) {
 	executor := setupExecutor("testExecutor1")
 	active := true
-	schedule := models.SchedulableEntity{
-		SchedulableEntityKey: models.SchedulableEntityKey{
-			Project: "project",
-			Domain:  "domain",
-			Name:    "cron_schedule",
-			Version: "v1",
-		},
-		CronExpression:      "*/1 * * * *",
-		KickoffTimeInputArg: "kickoff_time",
-		Active:              &active,
-	}
 	mockAdminClient.OnCreateExecutionMatch(context.Background(), mock.Anything).Return(&admin.ExecutionCreateResponse{}, nil)
-	err := executor.Execute(context.Background(), time.Now(), schedule)
-	assert.Nil(t, err)
+	t.Run("kickoff_time_arg", func(t *testing.T) {
+		schedule := models.SchedulableEntity{
+			SchedulableEntityKey: models.SchedulableEntityKey{
+				Project: "project",
+				Domain:  "domain",
+				Name:    "cron_schedule",
+				Version: "v1",
+			},
+			CronExpression:      "*/1 * * * *",
+			KickoffTimeInputArg: "kickoff_time",
+			Active:              &active,
+		}
+		err := executor.Execute(context.Background(), time.Now(), schedule)
+		assert.Nil(t, err)
+	})
+	t.Run("without kickoff_time_arg", func(t *testing.T) {
+		schedule := models.SchedulableEntity{
+			SchedulableEntityKey: models.SchedulableEntityKey{
+				Project: "project",
+				Domain:  "domain",
+				Name:    "cron_schedule",
+				Version: "v1",
+			},
+			CronExpression: "*/1 * * * *",
+			Active:         &active,
+		}
+		err := executor.Execute(context.Background(), time.Now(), schedule)
+		assert.Nil(t, err)
+	})
 }
 
 func TestExecutorAlreadyExists(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR

For fixed rate schedule the inmemory job store was not storing the handle entryID  to the scheduled job.

And this would cause the deschedule to silently not do anything since the handle entryId was never stored in the job.

Verified this by running a fixed rate schedule and descheduling it

Before the fix . the fixed rate schedule would not stop even on deactivation in case the scheduler hasn't been restarted.


```
flytectl update launchplan -d development -p flytesnacks my_fixed_rate_lp --version v1  --activate
```

```
flytectl get execution  -p flytesnacks -d development            
 ---------------------- ------------------ --------- ------------- ----------- ---------------------- -------------------------------- --------------- -------------------- -------------------- 
| NAME                 | LAUNCH PLAN NAME | VERSION | TYPE        | PHASE     | SCHEDULED TIME       | STARTED                        | ELAPSED TIME  | ABORT DATA (TRUNC) | ERROR DATA (TRUNC) |
 ---------------------- ------------------ --------- ------------- ----------- ---------------------- -------------------------------- --------------- -------------------- -------------------- 
| f1fa165b6c96daa42000 | my_fixed_rate_lp | v1      | LAUNCH_PLAN | SUCCEEDED | 2022-05-26T12:52:55Z | 2022-05-26T12:53:00.089373400Z | 49.022708800s |                    |                    |
 ---------------------- ------------------ --------- ------------- ----------- ---------------------- -------------------------------- --------------- -------------------- -------------------- 
| fcd9665b6c967aa42000 | my_fixed_rate_lp | v1      | LAUNCH_PLAN | SUCCEEDED | 2022-05-26T12:51:55Z | 2022-05-26T12:52:00.098199Z    | 49.095160200s |                    |                    |
 ------
```


```
flytectl update launchplan -d development -p flytesnacks my_fixed_rate_lp --version v1  --archive
```



Logs from the scheduler
```
{"json":{"src":"gocron_scheduler.go:286"},"level":"info","msg":"successfully removed the schedule 6798512435668175381 from scheduler for schedule {BaseModel:{ID:1 CreatedAt:2022-05-26 12:50:43.464766 +0000 UTC UpdatedAt:2022-05-26 12:50:43.464766 +0000 UTC DeletedAt:\u003cnil\u003e} SchedulableEntityKey:{Project:flytesnacks Domain:development Name:my_fixed_rate_lp Version:v1} CronExpression: FixedRateValue:1 Unit:MINUTE KickoffTimeInputArg: Active:0xc0008f43b0}","ts":"2022-05-26T12:53:25Z"}
```


### Also  fixes cron schedule for missing key

If the kickOffTimeArg is not passed in the scheduled launchplan then the execution create request shouldn't send the same .

Before the fix with the following schedule launchplan
```
@task
def format_date(run_date: datetime) -> str:
    return run_date.strftime("%Y-%m-%d %H:%M")

@workflow
def date_formatter_wf():
    formatted_kickoff_time = format_date(run_date=datetime.now())
    print(formatted_kickoff_time)


# creates a launch plan that runs every minute.
cron_lp = LaunchPlan.get_or_create(
    name="my_cron_scheduled_lp",
    workflow=date_formatter_wf,
    schedule=CronSchedule(
        # Note that kickoff_time_input_arg matches the workflow input we defined above: kickoff_time
        # But in case you are using the AWS scheme of schedules and not using the native scheduler then switch over the schedule parameter with cron_expression
        schedule="*/1 * * * *",  # Following schedule runs every min
    ),
)
```
Error : 
```
{"json":{"routine":"jobfunc-14131134336299703314","src":"executor_impl.go:110"},"level":"error","msg":"failed to create execution create request %+v due to %vproject:\"flytesnacks\" domain:\"development\" name:\"f5497c9144eeb81ac000\" spec:\u003claunch_plan:\u003cresource_type:LAUNCH_PLAN project:\"flytesnacks\" domain:\"development\" name:\"my_cron_scheduled_lp\" version:\"v1\" \u003e metadata:\u003cmode:SCHEDULED scheduled_at:\u003cseconds:1653636060 \u003e \u003e \u003e inputs:\u003cliterals:\u003ckey:\"\" value:\u003cscalar:\u003cprimitive:\u003cdatetime:\u003cseconds:1653636060 \u003e \u003e \u003e \u003e \u003e \u003e  rpc error: code = InvalidArgument desc = missing key in inputs","ts":"2022-05-27T07:21:01Z"}
```

After the fix 

```
- 
| f6aeeb8144eeb6dac000 | my_cron_scheduled_lp | v1      | LAUNCH_PLAN | SUCCEEDED | 2022-05-27T07:31:00Z | 2022-05-27T07:32:25.496421600Z | 40.079230900s |                    |                    |
 ---------------------- ---------------------- --------- ------------- ----------- ---------------------- -------------------------------- --------------- -------------------- -------------------- 
| f18e4b8144ee56dac000 | my_cron_scheduled_lp | v1      | LAUNCH_PLAN | SUCCEEDED | 2022-05-27T07:30:00Z | 2022-05-27T07:32:09.450155700Z | 56.028344s    |                    |                    |
 ---------------------- ---------------------- --------- ------------- ----------- ---------------------- -------------------------------- --------------- -------------------- -------------------- 
| ffb20bb144ee970ac000 | my_cron_scheduled_lp | v1      | LAUNCH_PLAN | SUCCEEDED | 2022-05-27T07:32:00Z | 2022-05-27T07:32:09.452813800Z | 56.010046400s |                    |                    |
 ---------------------- ---------------------- --------- ------------- ----------- ---------------------- -------------------------------- --------------- -------------------- -------------------- 
| f9f27c1144edb77ac000 | my_cron_scheduled_lp | v1      | LAUNCH_PLAN | SUCCEEDED | 2022-05-27T07:29:00Z | 2022-05-27T07:31:57.723865300Z | 37.538745800s |                    |                    |
 ---------------------- ---------------------- --------- ------------- ----------- ---------------------- -------------------------------- --------------- ------------
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/2552
fixes https://github.com/flyteorg/flyte/issues/2534

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
