### PR TITLE
Moving backward compat authrole code in one place and also removed redundant fields

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -511,6 +511,14 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 		if launchPlan.Spec.WorkflowId != nil {
 			workflowName = launchPlan.Spec.WorkflowId.Name
 		}
+		// Backward compatibility changes to get security context from auth role.
+		resolvedAuthRole := resolveAuthRole(request, launchPlan)
+		resolvedSecurityCtx := resolveSecurityCtx(ctx, workflowExecConfig.GetSecurityContext(), resolvedAuthRole)
+		if workflowExecConfig.GetSecurityContext() == nil &&
+			(len(resolvedSecurityCtx.GetRunAs().GetK8SServiceAccount()) > 0 ||
+				len(resolvedSecurityCtx.GetRunAs().GetIamRole()) > 0) {
+			workflowExecConfig.SecurityContext = resolvedSecurityCtx
+		}
 	}
 
 	matchableResource, err := util.GetMatchableResource(ctx, m.resourceManager,
@@ -524,6 +532,7 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 		workflowExecConfig = mergeIntoExecConfig(workflowExecConfig,
 			matchableResource.Attributes.GetWorkflowExecutionConfig())
 	}
+
 	//  merge the application config into workflowExecConfig
 	workflowExecConfig = mergeIntoExecConfig(workflowExecConfig, m.config.ApplicationConfiguration().GetTopLevelConfig())
 	logger.Infof(ctx, "getting the workflow execution config from application configuration")
@@ -669,16 +678,12 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		return nil, nil, err
 	}
 
-	resolvedAuthRole := resolveAuthRole(request, launchPlan)
-	resolvedSecurityCtx := resolveSecurityCtx(ctx, executionConfig.GetSecurityContext(), resolvedAuthRole)
-
 	executionParameters := workflowengineInterfaces.ExecutionParameters{
 		Inputs:              request.Inputs,
 		AcceptedAt:          requestedAt,
 		Labels:              labels,
 		Annotations:         annotations,
 		ExecutionConfig:     executionConfig,
-		SecurityContext:     resolvedSecurityCtx,
 		TaskResources:       &platformTaskResources,
 		EventVersion:        m.config.ApplicationConfiguration().GetTopLevelConfig().EventVersion,
 		RoleNameKey:         m.config.ApplicationConfiguration().GetTopLevelConfig().RoleNameKey,
@@ -746,7 +751,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		Cluster:               execInfo.Cluster,
 		InputsURI:             inputsURI,
 		UserInputsURI:         userInputsURI,
-		SecurityContext:       resolvedSecurityCtx,
+		SecurityContext:       executionConfig.SecurityContext,
 	})
 	if err != nil {
 		logger.Infof(ctx, "Failed to create execution model in transformer for id: [%+v] with err: %v",
@@ -757,7 +762,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 	return ctx, executionModel, nil
 }
 
-func resolveAuthRole(request admin.ExecutionCreateRequest, launchPlan *admin.LaunchPlan) *admin.AuthRole {
+func resolveAuthRole(request *admin.ExecutionCreateRequest, launchPlan *admin.LaunchPlan) *admin.AuthRole {
 	if request.Spec.AuthRole != nil {
 		return request.Spec.AuthRole
 	}
@@ -907,15 +912,12 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		return nil, nil, err
 	}
 
-	resolvedAuthRole := resolveAuthRole(request, launchPlan)
-	resolvedSecurityCtx := resolveSecurityCtx(ctx, executionConfig.GetSecurityContext(), resolvedAuthRole)
 	executionParameters := workflowengineInterfaces.ExecutionParameters{
 		Inputs:              executionInputs,
 		AcceptedAt:          requestedAt,
 		Labels:              labels,
 		Annotations:         annotations,
 		ExecutionConfig:     executionConfig,
-		SecurityContext:     resolvedSecurityCtx,
 		TaskResources:       &platformTaskResources,
 		EventVersion:        m.config.ApplicationConfiguration().GetTopLevelConfig().EventVersion,
 		RoleNameKey:         m.config.ApplicationConfiguration().GetTopLevelConfig().RoleNameKey,
@@ -984,7 +986,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 		Cluster:               execInfo.Cluster,
 		InputsURI:             inputsURI,
 		UserInputsURI:         userInputsURI,
-		SecurityContext:       resolvedSecurityCtx,
+		SecurityContext:       executionConfig.SecurityContext,
 	})
 	if err != nil {
 		logger.Infof(ctx, "Failed to create execution model in transformer for id: [%+v] with err: %v",

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -512,6 +512,11 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 			workflowName = launchPlan.Spec.WorkflowId.Name
 		}
 		// Backward compatibility changes to get security context from auth role.
+		// Older authRole in the launchplan spec or execution request need to be resolved and converted to newer security context.
+		// This portion of the code makes sure if newer way of setting security context is empty i.e
+		// K8sServiceAccount and  IamRole is empty then get the values from the deprecated fields.
+		// The older authRole values in launchplan spec or execution request take precedence here over the newer fields
+		// being set in matchable attributes.
 		resolvedAuthRole := resolveAuthRole(request, launchPlan)
 		resolvedSecurityCtx := resolveSecurityCtx(ctx, workflowExecConfig.GetSecurityContext(), resolvedAuthRole)
 		if workflowExecConfig.GetSecurityContext() == nil &&

--- a/pkg/workflowengine/impl/prepare_execution.go
+++ b/pkg/workflowengine/impl/prepare_execution.go
@@ -122,7 +122,7 @@ func PrepareFlyteWorkflow(data interfaces.ExecutionData, flyteWorkflow *v1alpha1
 
 	// add permissions from auth and security context. Adding permissions from auth would be removed once all clients
 	// have migrated over to security context
-	addPermissions(data.ExecutionParameters.SecurityContext,
+	addPermissions(data.ExecutionParameters.ExecutionConfig.SecurityContext,
 		data.ExecutionParameters.RoleNameKey, flyteWorkflow)
 
 	labels := addMapValues(data.ExecutionParameters.Labels, flyteWorkflow.Labels)

--- a/pkg/workflowengine/impl/prepare_execution_test.go
+++ b/pkg/workflowengine/impl/prepare_execution_test.go
@@ -191,15 +191,15 @@ func TestPrepareFlyteWorkflow(t *testing.T) {
 					MissingPluginBehavior: admin.PluginOverride_USE_DEFAULT,
 				},
 			},
-			SecurityContext: &core.SecurityContext{
-				RunAs: &core.Identity{
-					IamRole:           testRoleSc,
-					K8SServiceAccount: testK8sServiceAccountSc,
-				},
-			},
 			ExecutionConfig: &admin.WorkflowExecutionConfig{
 				MaxParallelism: 50,
 				Interruptible:  &wrappers.BoolValue{Value: true},
+				SecurityContext: &core.SecurityContext{
+					RunAs: &core.Identity{
+						IamRole:           testRoleSc,
+						K8SServiceAccount: testK8sServiceAccountSc,
+					},
+				},
 			},
 			RecoveryExecution: recoveryNodeExecutionID,
 			EventVersion:      1,

--- a/pkg/workflowengine/interfaces/executor.go
+++ b/pkg/workflowengine/interfaces/executor.go
@@ -24,7 +24,6 @@ type ExecutionParameters struct {
 	Annotations         map[string]string
 	TaskPluginOverrides []*admin.PluginOverride
 	ExecutionConfig     *admin.WorkflowExecutionConfig
-	SecurityContext     *core.SecurityContext
 	RecoveryExecution   *core.WorkflowExecutionIdentifier
 	TaskResources       *TaskResources
 	EventVersion        int


### PR DESCRIPTION

Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>


# TL;DR
With the introduction of the default values in service account 
https://github.com/flyteorg/flyteadmin/blob/6e03bd4ac2ad3bb950e8fa1ed64f4bc5c6058bcd/pkg/runtime/application_config_provider.go#L34

And this logic 
https://github.com/flyteorg/flyteadmin/blob/6e03bd4ac2ad3bb950e8fa1ed64f4bc5c6058bcd/pkg/manager/impl/execution_manager.go#L788


Hence even if authRole  which is deprecated field was set in launchplan or execution request, it was being ignored
since this logic was being resolved after the application default values were added.


Also as part of this PR cleaned up redundant fields in ExecutionParameters for Security Context and fetching those from 


## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
