### PR TITLE
Show non-PgError errors when connecting to db

### DIFF
--- a/pkg/repositories/errors/postgres.go
+++ b/pkg/repositories/errors/postgres.go
@@ -104,8 +104,3 @@ func NewPostgresErrorTransformer(scope promutils.Scope) ErrorTransformer {
 		metrics: metrics,
 	}
 }
-
-type ConnectError interface {
-	Unwrap() error
-	Error() string
-}


### PR DESCRIPTION
# TL;DR
When network (or other non-database) errors occur while connecting to the database, the error is masked by a panic due to a bug in unwrapping the error.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

When connecting to a database instance that doesn't exist, that error is currently masked due to an invalid assumption that all wrapped errors returned from gorm are of type `*pgconn.PgError`. When a network error occurs, the returned error is of type `*net.OpError`. This causes the following panic -

```
{"json":{"src":"base.go:73"},"level":"fatal","msg":"caught panic: interface conversion: error is *net.OpError, not *pgconn.PgError [goroutine 1 [running]:\nruntime/debug.Stack()\n\t/home/user/.local/go/src/runtime/debug/stack.go:24
...
```

... and doesn't show what the actual error is.

This PR fixes that by using the functions in the `errors` package to check if the error chain contains an error of type `*pgconn.PgError`, and if not, simply returns the error.

It also removes the ConnectError interface, as it is no longer needed - the `errors.As` function will automatically check the whole error chain and unwrap as necessary.

With this fix, the error becomes -

```
{"json":{"src":"base.go:82"},"level":"fatal","msg":"failed to connect to `host=localhost user=postgres database=flyte`: dial error (dial tcp 127.0.0.1:5432: connect: connection refused)","ts":"2022-06-11T20:48:28+01:00"}
```

## Tracking Issue
N/A

## Follow-up issue
N/A