### PR TITLE
Cannot abort an already terminated execution

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -1650,6 +1650,9 @@ func (m *ExecutionManager) TerminateExecution(
 		logger.Infof(ctx, "couldn't find execution [%+v] to save termination cause", request.Id)
 		return nil, err
 	}
+	if common.IsExecutionTerminal(core.WorkflowExecution_Phase(core.WorkflowExecution_Phase_value[executionModel.Phase])) {
+		return nil, errors.NewFlyteAdminError(codes.PermissionDenied, "Cannot abort an already terminate workflow execution")
+	}
 
 	err = transformers.SetExecutionAborting(&executionModel, request.Cause, getUser(ctx))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Cannot abort an already terminated execution. Verify the existing execution state before updating to 'ABORTING' and issuing an abort request with the workflow executor.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2653

## Follow-up issue
_NA_
