### PR TITLE
Increase `allowedExecutionNameLength` to 63

### DIFF
--- a/pkg/manager/impl/validation/execution_validator.go
+++ b/pkg/manager/impl/validation/execution_validator.go
@@ -16,7 +16,8 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-const allowedExecutionNameLength = 20
+// Maximum value length of a Kubernetes label
+const allowedExecutionNameLength = 63
 
 var executionIDRegex = regexp.MustCompile(`^[a-z][a-z\-0-9]*$`)
 

--- a/pkg/manager/impl/validation/execution_validator_test.go
+++ b/pkg/manager/impl/validation/execution_validator_test.go
@@ -162,9 +162,9 @@ func TestValidExecutionId(t *testing.T) {
 }
 
 func TestValidExecutionIdInvalidLength(t *testing.T) {
-	err := CheckValidExecutionID("abcdeasdasdasdasdasdasdasd123", "a")
+	err := CheckValidExecutionID("abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc", "a")
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "size of a exceeded length 20 : abcdeasdasdasdasdasdasdasd123")
+	assert.EqualError(t, err, "size of a exceeded length 63 : abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc")
 }
 
 func TestValidExecutionIdInvalidChars(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Rahul Mehta <98349643+rahul-theorem@users.noreply.github.com>

# TL;DR
Increase `allowedExecutionNameLength` from 20 to 63 to allow more legible human-readable execution IDs

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See title/summary

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/2824

## Follow-up issue
_NA_