### PR TITLE
Added type assertion check on scp claims which are returned as string in Azure AD

### DIFF
--- a/auth/authzserver/claims_verifier.go
+++ b/auth/authzserver/claims_verifier.go
@@ -47,10 +47,14 @@ func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}
 
 	scopes := sets.NewString()
 	if scopesClaim, found := claimsRaw[ScopeClaim]; found {
-		if scopesSlice, ok := scopesClaim.([]interface{}); ok {
-			scopes = sets.NewString(interfaceSliceToStringSlice(scopesSlice)...)
-		} else {
-			scopes = sets.NewString(fmt.Sprintf("%v", scopesClaim))
+
+		switch sct := scopesClaim.(type) {
+		case []interface{}:
+			scopes = sets.NewString(interfaceSliceToStringSlice(sct)...)
+		case string:
+			sets.NewString(fmt.Sprintf("%v", scopesClaim))
+		default:
+			return nil, fmt.Errorf("failed getting scope claims due to  unknown type %T with value %v", sct, sct)
 		}
 	}
 

--- a/auth/authzserver/claims_verifier.go
+++ b/auth/authzserver/claims_verifier.go
@@ -1,0 +1,64 @@
+package authzserver
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ory/x/jwtx"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/flyteorg/flyteadmin/auth"
+	"github.com/flyteorg/flyteadmin/auth/interfaces"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
+)
+
+func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}) (interfaces.IdentityContext, error) {
+	claims := jwtx.ParseMapStringInterfaceClaims(claimsRaw)
+
+	foundAudIndex := -1
+	for audIndex, aud := range claims.Audience {
+		if expectedAudience.Has(aud) {
+			foundAudIndex = audIndex
+			break
+		}
+	}
+
+	if foundAudIndex < 0 {
+		return nil, fmt.Errorf("invalid audience [%v]", claims)
+	}
+
+	userInfo := &service.UserInfoResponse{}
+	if userInfoClaim, found := claimsRaw[UserIDClaim]; found && userInfoClaim != nil {
+		userInfoRaw := userInfoClaim.(map[string]interface{})
+		raw, err := json.Marshal(userInfoRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = json.Unmarshal(raw, userInfo); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal user info claim into UserInfo type. Error: %w", err)
+		}
+	}
+
+	clientID := ""
+	if clientIDClaim, found := claimsRaw[ClientIDClaim]; found {
+		clientID = clientIDClaim.(string)
+	}
+
+	scopes := sets.NewString()
+	if scopesClaim, found := claimsRaw[ScopeClaim]; found {
+		if scopesSlice, ok := scopesClaim.([]interface{}); ok {
+			scopes = sets.NewString(interfaceSliceToStringSlice(scopesSlice)...)
+		} else {
+			scopes = sets.NewString(fmt.Sprintf("%v", scopesClaim))
+		}
+	}
+
+	// If this is a user-only access token with no scopes defined then add `all` scope by default because it's equivalent
+	// to having a user's login cookie or an ID Token as means of accessing the service.
+	if len(clientID) == 0 && scopes.Len() == 0 {
+		scopes.Insert(auth.ScopeAll)
+	}
+
+	return auth.NewIdentityContext(claims.Audience[foundAudIndex], claims.Subject, clientID, claims.IssuedAt, scopes, userInfo, claimsRaw), nil
+}

--- a/auth/authzserver/claims_verifier_test.go
+++ b/auth/authzserver/claims_verifier_test.go
@@ -1,0 +1,87 @@
+package authzserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func Test_verifyClaims(t *testing.T) {
+	t.Run("Empty claims, fail", func(t *testing.T) {
+		_, err := verifyClaims(sets.NewString("https://myserver"), map[string]interface{}{})
+		assert.Error(t, err)
+	})
+
+	t.Run("All filled", func(t *testing.T) {
+		identityCtx, err := verifyClaims(sets.NewString("https://myserver"), map[string]interface{}{
+			"aud": []string{"https://myserver"},
+			"user_info": map[string]interface{}{
+				"preferred_name": "John Doe",
+			},
+			"sub":       "123",
+			"client_id": "my-client",
+			"scp":       []interface{}{"all", "offline"},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, sets.NewString("all", "offline"), identityCtx.Scopes())
+		assert.Equal(t, "my-client", identityCtx.AppID())
+		assert.Equal(t, "123", identityCtx.UserID())
+		assert.Equal(t, "https://myserver", identityCtx.Audience())
+	})
+
+	t.Run("Multiple audience", func(t *testing.T) {
+		identityCtx, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver"},
+				"user_info": map[string]interface{}{
+					"preferred_name": "John Doe",
+				},
+				"sub":       "123",
+				"client_id": "my-client",
+				"scp":       []interface{}{"all", "offline"},
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "https://myserver", identityCtx.Audience())
+	})
+
+	t.Run("No matching audience", func(t *testing.T) {
+		_, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver3"},
+			})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid audience")
+	})
+
+	t.Run("Use first matching audience", func(t *testing.T) {
+		identityCtx, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2", "https://myserver3"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver", "https://myserver2"},
+				"user_info": map[string]interface{}{
+					"preferred_name": "John Doe",
+				},
+				"sub":       "123",
+				"client_id": "my-client",
+				"scp":       []interface{}{"all", "offline"},
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "https://myserver", identityCtx.Audience())
+	})
+
+	t.Run("String scope", func(t *testing.T) {
+		identityCtx, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver"},
+				"scp": "all",
+			})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "https://myserver", identityCtx.Audience())
+		assert.Equal(t, sets.NewString("all"), identityCtx.Scopes())
+	})
+}

--- a/auth/authzserver/claims_verifier_test.go
+++ b/auth/authzserver/claims_verifier_test.go
@@ -84,4 +84,15 @@ func Test_verifyClaims(t *testing.T) {
 		assert.Equal(t, "https://myserver", identityCtx.Audience())
 		assert.Equal(t, sets.NewString("all"), identityCtx.Scopes())
 	})
+	t.Run("unknown scope", func(t *testing.T) {
+		identityCtx, err := verifyClaims(sets.NewString("https://myserver", "https://myserver2"),
+			map[string]interface{}{
+				"aud": []string{"https://myserver"},
+				"scp": 1,
+			})
+
+		assert.Error(t, err)
+		assert.Nil(t, identityCtx)
+		assert.Equal(t, "failed getting scope claims due to  unknown type int with value 1", err.Error())
+	})
 }

--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -166,7 +166,11 @@ func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}
 
 	scopes := sets.NewString()
 	if scopesClaim, found := claimsRaw[ScopeClaim]; found {
-		scopes = sets.NewString(interfaceSliceToStringSlice(scopesClaim.([]interface{}))...)
+		if scopesSlice, ok := scopesClaim.([]interface{}); ok {
+			scopes = sets.NewString(interfaceSliceToStringSlice(scopesSlice)...)
+		} else {
+			scopes = sets.NewString().Insert(fmt.Sprintf("%v", scopesClaim))
+		}
 	}
 
 	// If this is a user-only access token with no scopes defined then add `all` scope by default because it's equivalent

--- a/auth/authzserver/provider.go
+++ b/auth/authzserver/provider.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"time"
@@ -16,8 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/lestrrat-go/jwx/jwk"
-
-	"github.com/ory/x/jwtx"
 
 	"github.com/flyteorg/flyteadmin/auth/interfaces"
 
@@ -129,57 +126,6 @@ func (p Provider) ValidateAccessToken(ctx context.Context, expectedAudience, tok
 
 	claimsRaw := parsedToken.Claims.(jwtgo.MapClaims)
 	return verifyClaims(sets.NewString(expectedAudience), claimsRaw)
-}
-
-func verifyClaims(expectedAudience sets.String, claimsRaw map[string]interface{}) (interfaces.IdentityContext, error) {
-	claims := jwtx.ParseMapStringInterfaceClaims(claimsRaw)
-
-	foundAudIndex := -1
-	for audIndex, aud := range claims.Audience {
-		if expectedAudience.Has(aud) {
-			foundAudIndex = audIndex
-			break
-		}
-	}
-
-	if foundAudIndex < 0 {
-		return nil, fmt.Errorf("invalid audience [%v]", claims)
-	}
-
-	userInfo := &service.UserInfoResponse{}
-	if userInfoClaim, found := claimsRaw[UserIDClaim]; found && userInfoClaim != nil {
-		userInfoRaw := userInfoClaim.(map[string]interface{})
-		raw, err := json.Marshal(userInfoRaw)
-		if err != nil {
-			return nil, err
-		}
-
-		if err = json.Unmarshal(raw, userInfo); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal user info claim into UserInfo type. Error: %w", err)
-		}
-	}
-
-	clientID := ""
-	if clientIDClaim, found := claimsRaw[ClientIDClaim]; found {
-		clientID = clientIDClaim.(string)
-	}
-
-	scopes := sets.NewString()
-	if scopesClaim, found := claimsRaw[ScopeClaim]; found {
-		if scopesSlice, ok := scopesClaim.([]interface{}); ok {
-			scopes = sets.NewString(interfaceSliceToStringSlice(scopesSlice)...)
-		} else {
-			scopes = sets.NewString().Insert(fmt.Sprintf("%v", scopesClaim))
-		}
-	}
-
-	// If this is a user-only access token with no scopes defined then add `all` scope by default because it's equivalent
-	// to having a user's login cookie or an ID Token as means of accessing the service.
-	if len(clientID) == 0 && scopes.Len() == 0 {
-		scopes.Insert(auth.ScopeAll)
-	}
-
-	return auth.NewIdentityContext(claims.Audience[foundAudIndex], claims.Subject, clientID, claims.IssuedAt, scopes, userInfo, claimsRaw), nil
 }
 
 // NewProvider creates a new OAuth2 Provider that is able to do OAuth 2-legged and 3-legged flows. It'll lookup


### PR DESCRIPTION

Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Moved claim verification to separate file as it consumed by both the provider and resource_server implementations
And added type assertion check for scp claims to avoid this trace

```
flyteadmin-b6b9c465c-vgj57 flyteadmin {"json":{"src":"handlers.go:237"},"level":"debug","msg":"Running authentication gRPC interceptor","ts":"2022-09-06T06:15:34Z"}
flyteadmin-b6b9c465c-vgj57 flyteadmin panic: interface conversion: interface {} is string, not []interface {}
flyteadmin-b6b9c465c-vgj57 flyteadmin
flyteadmin-b6b9c465c-vgj57 flyteadmin goroutine 1772 [running]:
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/flyteorg/flyteadmin/auth/authzserver.verifyClaims(0x23975a0?, 0xc001efb440)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/src/github.com/flyteorg/flyteadmin/auth/authzserver/provider.go:169 +0x7a6
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/flyteorg/flyteadmin/auth/authzserver.ResourceServer.ValidateAccessToken({{0x2988b00, 0xc0001fee70}, {0xc000a691a0, 0x3, 0x3}}, {0x29ace40?, 0xc001d3d410?}, {0xc001bf2600, 0x20}, {0xc00097b507, ...})
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/src/github.com/flyteorg/flyteadmin/auth/authzserver/resource_server.go:46 +0x2df
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/flyteorg/flyteadmin/auth.GRPCGetIdentityFromAccessToken({0x29ace40, 0xc001d3d410}, {0x29b6ea0, 0xc000848120})
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/src/github.com/flyteorg/flyteadmin/auth/token.go:93 +0x1e5
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/flyteorg/flyteadmin/auth.GetAuthenticationInterceptor.func1({0x29ace40, 0xc001d3d410})
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/src/github.com/flyteorg/flyteadmin/auth/handlers.go:242 +0xaf
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/grpc-ecosystem/go-grpc-middleware/auth.UnaryServerInterceptor.func1({0x29ace40, 0xc001d3d410}, {0x2375fe0, 0xc001c7da40}, 0xc001c3e5e0, 0xc001c3e620)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/auth/auth.go:42 +0x93
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x29ace40?, 0xc001d3d410?}, {0x2375fe0?, 0xc001c7da40?})
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25 +0x3a
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/flyteorg/flyteadmin/auth.GetAuthenticationCustomMetadataInterceptor.func1({0x29ace40, 0xc001d3c300}, {0x2375fe0, 0xc001c7da40}, 0x20?, 0xc001c3e640)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/src/github.com/flyteorg/flyteadmin/auth/handlers.go:213 +0x323
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x29ace40?, 0xc001d3c300?}, {0x2375fe0?, 0xc001c7da40?})
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25 +0x3a
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1({0x29ace40, 0xc001d3c300}, {0x2375fe0, 0xc001c7da40}, 0x7f03ac8576d8?, 0xc001c3e660)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0x87
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x29ace40?, 0xc001d3c300?}, {0x2375fe0?, 0xc001c7da40?})
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25 +0x3a
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1({0x29ace40, 0xc001d3c300}, {0x2375fe0, 0xc001c7da40}, 0xc001a9eaf0?, 0x20f35e0?)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:34 +0xbf
flyteadmin-b6b9c465c-vgj57 flyteadmin github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service._AdminService_ListProjects_Handler({0x2444fa0?, 0xc001529000}, {0x29ace40, 0xc001d3c300}, 0xc001cfefc0, 0xc000e111d0)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/github.com/flyteorg/flyteidl@v1.1.5/gen/pb-go/flyteidl/service/admin.pb.go:1576 +0x138
flyteadmin-b6b9c465c-vgj57 flyteadmin google.golang.org/grpc.(*Server).processUnaryRPC(0xc000d1b180, {0x29b5708, 0xc001a7f1e0}, 0xc000a5b0e0, 0xc000a4d200, 0x3c66e58, 0x0)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:1283 +0xcfd
flyteadmin-b6b9c465c-vgj57 flyteadmin google.golang.org/grpc.(*Server).handleStream(0xc000d1b180, {0x29b5708, 0xc001a7f1e0}, 0xc000a5b0e0, 0x0)
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:1620 +0xa1b
flyteadmin-b6b9c465c-vgj57 flyteadmin google.golang.org/grpc.(*Server).serveStreams.func1.2()
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:922 +0x98
flyteadmin-b6b9c465c-vgj57 flyteadmin created by google.golang.org/grpc.(*Server).serveStreams.func1
flyteadmin-b6b9c465c-vgj57 flyteadmin 	/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:920 +0x28a
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/2860

## Follow-up issue
_NA_
