### PR TITLE
Fix query for NodeExecutionsRepo.Count

### DIFF
--- a/pkg/repositories/gormimpl/node_execution_repo.go
+++ b/pkg/repositories/gormimpl/node_execution_repo.go
@@ -198,12 +198,14 @@ func (r *NodeExecutionRepo) Exists(ctx context.Context, input interfaces.NodeExe
 
 func (r *NodeExecutionRepo) Count(ctx context.Context, input interfaces.CountResourceInput) (int64, error) {
 	var err error
-	tx := r.db.Model(&models.NodeExecution{})
+	tx := r.db.Model(&models.NodeExecution{}).Preload("ChildNodeExecutions")
 
 	// Add join condition (joining multiple tables is fine even we only filter on a subset of table attributes).
 	// (this query isn't called for deletes).
-	tx = tx.Joins(innerJoinNodeExecToNodeEvents)
-	tx = tx.Joins(innerJoinExecToNodeExec)
+	tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.execution_project = %s.execution_project AND "+
+		"%s.execution_domain = %s.execution_domain AND %s.execution_name = %s.execution_name",
+		executionTableName, nodeExecutionTableName, executionTableName,
+		nodeExecutionTableName, executionTableName, nodeExecutionTableName, executionTableName))
 
 	// Apply filters
 	tx, err = applyScopedFilters(tx, input.InlineFilters, input.MapFilters)

--- a/pkg/repositories/gormimpl/node_execution_repo_test.go
+++ b/pkg/repositories/gormimpl/node_execution_repo_test.go
@@ -466,7 +466,7 @@ func TestCountNodeExecutions_Filters(t *testing.T) {
 
 	GlobalMock := mocket.Catcher.Reset()
 	GlobalMock.NewMock().WithQuery(
-		`SELECT count(*) FROM "node_executions" INNER JOIN node_executions ON node_event_executions.node_execution_id = node_executions.id INNER JOIN executions ON node_executions.execution_project = executions.execution_project AND node_executions.execution_domain = executions.execution_domain AND node_executions.execution_name = executions.execution_name WHERE node_executions.phase = $1 AND "error_code" IS NULL`).WithReply([]map[string]interface{}{{"rows": 3}})
+		`SELECT count(*) FROM "node_executions" INNER JOIN executions ON node_executions.execution_project = executions.execution_project AND node_executions.execution_domain = executions.execution_domain AND node_executions.execution_name = executions.execution_name WHERE node_executions.phase = $1 AND "node_executions"."error_code" IS NULL`).WithReply([]map[string]interface{}{{"rows": 3}})
 
 	count, err := nodeExecutionRepo.Count(context.Background(), interfaces.CountResourceInput{
 		InlineFilters: []common.InlineFilter{
@@ -474,7 +474,7 @@ func TestCountNodeExecutions_Filters(t *testing.T) {
 		},
 		MapFilters: []common.MapFilter{
 			common.NewMapFilter(map[string]interface{}{
-				"error_code": nil,
+				"\"node_executions\".\"error_code\"": nil,
 			}),
 		},
 	})


### PR DESCRIPTION
Signed-off-by: Andrew Dye <andrewwdye@gmail.com>

# TL;DR
Recently added query for `NodeExecutionsRepo.Count` is broken. This change updates the query to be consistent with `NodeExecutionsRepo.List`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The `NodeExecutionsRepo.Count` borrowed join conditions from `NodeExecutionsRepo.ListEvents`, which is currently broken. This change fixes the query to match `NodeExecutionsRepo.List`. I updated the unittest and validated the change with a local instance of flyteadmin and postgres.

## Tracking Issue
NA

## Follow-up issue
Opened https://github.com/flyteorg/flyte/issues/2858 for the broken `ListEvents` implementation.
