### PR TITLE
Remove unused join condition

### DIFF
--- a/pkg/repositories/gormimpl/common.go
+++ b/pkg/repositories/gormimpl/common.go
@@ -23,7 +23,6 @@ const ID = "id"
 const executionTableName = "executions"
 const namedEntityMetadataTableName = "named_entity_metadata"
 const nodeExecutionTableName = "node_executions"
-const nodeExecutionEventTableName = "node_event_executions"
 const taskExecutionTableName = "task_executions"
 const taskTableName = "tasks"
 
@@ -43,10 +42,6 @@ var entityToTableName = map[common.Entity]string{
 	common.NamedEntity:         "entities",
 	common.NamedEntityMetadata: "named_entity_metadata",
 }
-
-var innerJoinNodeExecToNodeEvents = fmt.Sprintf(
-	"INNER JOIN %s ON %s.node_execution_id = %s.id",
-	nodeExecutionTableName, nodeExecutionEventTableName, nodeExecutionTableName)
 
 var innerJoinExecToNodeExec = fmt.Sprintf(
 	"INNER JOIN %s ON %s.execution_project = %s.execution_project AND "+


### PR DESCRIPTION
# TL;DR
Remove unused `innerJoinNodeExecToNodeEvents` var to satisfy linter

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Two PRs dropping references to `innerJoinNodeExecToNodeEvents` raced, leading to both lint checks succeeding on PR (relative to master), but the second failing when merged. This change removes the defunct var.

Racing PRs:
https://github.com/flyteorg/flyteadmin/pull/472
https://github.com/flyteorg/flyteadmin/pull/473

## Tracking Issue
NA

## Follow-up issue
NA