### PR TITLE
#minor Add default execution cluster option for a multi-cluster setup

### DIFF
--- a/pkg/executioncluster/impl/random_cluster_selector_test.go
+++ b/pkg/executioncluster/impl/random_cluster_selector_test.go
@@ -23,14 +23,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testProject = "project"
-const testDomain = "domain"
-const testWorkflow = "name"
-
 const (
-	testCluster1 = "testcluster1"
-	testCluster2 = "testcluster2"
-	testCluster3 = "testcluster3"
+	testProject                    = "project"
+	testDomain                     = "domain"
+	testWorkflow                   = "name"
+	testCluster1                   = "testcluster1"
+	testCluster2                   = "testcluster2"
+	testCluster3                   = "testcluster3"
+	clusterConfig1                 = "clusters_config.yaml"
+	clusterConfig2                 = "clusters_config2.yaml"
+	clusterConfig2WithDefaultLabel = "clusters_config2_default_label.yaml"
 )
 
 func initTestConfig(fileName string) error {
@@ -47,7 +49,7 @@ func initTestConfig(fileName string) error {
 }
 
 func getRandomClusterSelectorForTest(t *testing.T) interfaces2.ClusterInterface {
-	err := initTestConfig("clusters_config.yaml")
+	err := initTestConfig(clusterConfig1)
 	assert.NoError(t, err)
 
 	db := repo_mock.NewMockRepository()
@@ -102,6 +104,74 @@ func getRandomClusterSelectorForTest(t *testing.T) interfaces2.ClusterInterface 
 	targets := map[string]*executioncluster.ExecutionTarget{
 		testCluster1: {
 			ID: testCluster1,
+		},
+		testCluster2: {
+			ID:      testCluster2,
+			Enabled: true,
+		},
+		testCluster3: {
+			ID:      testCluster3,
+			Enabled: true,
+		},
+	}
+	listTargetsProvider.OnGetValidTargets().Return(validTargets)
+	listTargetsProvider.OnGetAllTargets().Return(targets)
+	randomCluster, err := NewRandomClusterSelector(&listTargetsProvider, configProvider, db)
+	assert.NoError(t, err)
+	return randomCluster
+}
+
+func getRandomClusterSelectorWithDefaultLabelForTest(t *testing.T, configFile string) interfaces2.ClusterInterface {
+	err := initTestConfig(configFile)
+	assert.NoError(t, err)
+
+	db := repo_mock.NewMockRepository()
+	db.ResourceRepo().(*repo_mock.MockResourceRepo).GetFunction = func(ctx context.Context, ID repo_interface.ResourceID) (resource models.Resource, e error) {
+		assert.Equal(t, "EXECUTION_CLUSTER_LABEL", ID.ResourceType)
+		if ID.Project == "" {
+			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.NotFound,
+				"Resource [%+v] not found", ID)
+		}
+		response := models.Resource{
+			Project:      ID.Project,
+			Domain:       ID.Domain,
+			Workflow:     ID.Workflow,
+			ResourceType: ID.ResourceType,
+			LaunchPlan:   ID.LaunchPlan,
+		}
+		if ID.Project == testProject && ID.Domain == testDomain {
+			matchingAttributes := &admin.MatchingAttributes{
+				Target: &admin.MatchingAttributes_ExecutionClusterLabel{
+					ExecutionClusterLabel: &admin.ExecutionClusterLabel{
+						Value: "two",
+					},
+				},
+			}
+			marshalledMatchingAttributes, _ := proto.Marshal(matchingAttributes)
+			response.Attributes = marshalledMatchingAttributes
+		}
+		return response, nil
+	}
+	configProvider := runtime.NewConfigurationProvider()
+	listTargetsProvider := mocks.ListTargetsInterface{}
+	validTargets := map[string]*executioncluster.ExecutionTarget{
+		testCluster1: {
+			ID:      testCluster1,
+			Enabled: true,
+		},
+		testCluster2: {
+			ID:      testCluster2,
+			Enabled: true,
+		},
+		testCluster3: {
+			ID:      testCluster3,
+			Enabled: true,
+		},
+	}
+	targets := map[string]*executioncluster.ExecutionTarget{
+		testCluster1: {
+			ID:      testCluster1,
+			Enabled: true,
 		},
 		testCluster2: {
 			ID:      testCluster2,
@@ -197,4 +267,43 @@ func TestRandomClusterSelectorGetAllValidTargets(t *testing.T) {
 	cluster := getRandomClusterSelectorForTest(t)
 	targets := cluster.GetValidTargets()
 	assert.Equal(t, 2, len(targets))
+}
+
+func TestRandomClusterSelectorGetTargetWithFallbackToDefault1(t *testing.T) {
+	cluster := getRandomClusterSelectorWithDefaultLabelForTest(t, clusterConfig2)
+	target, err := cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
+		Project:     testProject,
+		Domain:      "different",
+		Workflow:    testWorkflow,
+		ExecutionID: "e3",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, testCluster3, target.ID)
+	assert.True(t, target.Enabled)
+}
+
+func TestRandomClusterSelectorGetTargetWithFallbackToDefault2(t *testing.T) {
+	cluster := getRandomClusterSelectorWithDefaultLabelForTest(t, clusterConfig2)
+	target, err := cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
+		Project:     testProject,
+		Domain:      testDomain,
+		Workflow:    testWorkflow,
+		ExecutionID: "e3",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, testCluster2, target.ID)
+	assert.True(t, target.Enabled)
+}
+
+func TestRandomClusterSelectorGetTargetWithFallbackToDefault3(t *testing.T) {
+	cluster := getRandomClusterSelectorWithDefaultLabelForTest(t, clusterConfig2WithDefaultLabel)
+	target, err := cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
+		Project:     testProject,
+		Domain:      "different",
+		Workflow:    testWorkflow,
+		ExecutionID: "e3",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, testCluster1, target.ID)
+	assert.True(t, target.Enabled)
 }

--- a/pkg/executioncluster/impl/testdata/clusters_config2.yaml
+++ b/pkg/executioncluster/impl/testdata/clusters_config2.yaml
@@ -1,0 +1,34 @@
+clusters:
+  labelClusterMap:
+    one:
+      - id: testcluster1
+        weight: 1
+    two:
+      - id: testcluster2
+        weight: 1
+    three:
+      - id: testcluster3
+        weight: 1        
+  clusterConfigs:
+  - name: "testcluster1"
+    endpoint: "testcluster1_endpoint"
+    enabled: true
+    auth:
+      type: "file_path"
+      tokenPath: "/path/to/testcluster1/token"
+      certPath: "/path/to/testcluster1/cert"  
+  - name: "testcluster2"
+    endpoint: "testcluster2_endpoint"
+    enabled: true
+    auth:
+      type: "file_path"
+      tokenPath: "/path/to/testcluster2/token"
+      certPath: "/path/to/testcluster2/cert"
+  - name: "testcluster3"
+    endpoint: "testcluster2_endpoint"
+    enabled: true
+    auth:
+      type: "file_path"
+      tokenPath: "/path/to/testcluster2/token"
+      certPath: "/path/to/testcluster2/cert"      
+

--- a/pkg/executioncluster/impl/testdata/clusters_config2_default_label.yaml
+++ b/pkg/executioncluster/impl/testdata/clusters_config2_default_label.yaml
@@ -1,0 +1,35 @@
+clusters:
+  defaultExecutionLabel: one
+  labelClusterMap:
+    one:
+      - id: testcluster1
+        weight: 1
+    two:
+      - id: testcluster2
+        weight: 1
+    three:
+      - id: testcluster3
+        weight: 1        
+  clusterConfigs:
+  - name: "testcluster1"
+    endpoint: "testcluster1_endpoint"
+    enabled: true
+    auth:
+      type: "file_path"
+      tokenPath: "/path/to/testcluster1/token"
+      certPath: "/path/to/testcluster1/cert"  
+  - name: "testcluster2"
+    endpoint: "testcluster2_endpoint"
+    enabled: true
+    auth:
+      type: "file_path"
+      tokenPath: "/path/to/testcluster2/token"
+      certPath: "/path/to/testcluster2/cert"
+  - name: "testcluster3"
+    endpoint: "testcluster2_endpoint"
+    enabled: true
+    auth:
+      type: "file_path"
+      tokenPath: "/path/to/testcluster2/token"
+      certPath: "/path/to/testcluster2/cert"      
+

--- a/pkg/runtime/cluster_config_provider.go
+++ b/pkg/runtime/cluster_config_provider.go
@@ -35,6 +35,15 @@ func (p *ClusterConfigurationProvider) GetClusterConfigs() []interfaces.ClusterC
 	return make([]interfaces.ClusterConfig, 0)
 }
 
+func (p *ClusterConfigurationProvider) GetDefaultExecutionLabel() string {
+	if clusterConfig != nil {
+		clusters := clusterConfig.GetConfig().(*interfaces.Clusters)
+		return clusters.DefaultExecutionLabel
+	}
+	logger.Debug(context.Background(), "Failed to find default execution label in config. Will use random cluster if no execution label matches.")
+	return ""
+}
+
 func NewClusterConfigurationProvider() interfaces.ClusterConfiguration {
 	clusterConfigProvider := ClusterConfigurationProvider{}
 	clusterNameMap := make(map[string]bool)

--- a/pkg/runtime/interfaces/cluster_configuration.go
+++ b/pkg/runtime/interfaces/cluster_configuration.go
@@ -42,8 +42,9 @@ func (auth Auth) GetToken() (string, error) {
 }
 
 type Clusters struct {
-	ClusterConfigs  []ClusterConfig            `json:"clusterConfigs"`
-	LabelClusterMap map[string][]ClusterEntity `json:"labelClusterMap"`
+	ClusterConfigs        []ClusterConfig            `json:"clusterConfigs"`
+	LabelClusterMap       map[string][]ClusterEntity `json:"labelClusterMap"`
+	DefaultExecutionLabel string                     `json:"defaultExecutionLabel"`
 }
 
 //go:generate mockery -name ClusterConfiguration -case=underscore -output=../mocks -case=underscore
@@ -56,4 +57,7 @@ type ClusterConfiguration interface {
 
 	// Returns label cluster map for routing
 	GetLabelClusterMap() map[string][]ClusterEntity
+
+	// Returns default execution label used as fallback if no execution cluster was explicitly defined.
+	GetDefaultExecutionLabel() string
 }

--- a/pkg/runtime/mocks/cluster_configuration.go
+++ b/pkg/runtime/mocks/cluster_configuration.go
@@ -46,6 +46,38 @@ func (_m *ClusterConfiguration) GetClusterConfigs() []interfaces.ClusterConfig {
 	return r0
 }
 
+type ClusterConfiguration_GetDefaultExecutionLabel struct {
+	*mock.Call
+}
+
+func (_m ClusterConfiguration_GetDefaultExecutionLabel) Return(_a0 string) *ClusterConfiguration_GetDefaultExecutionLabel {
+	return &ClusterConfiguration_GetDefaultExecutionLabel{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *ClusterConfiguration) OnGetDefaultExecutionLabel() *ClusterConfiguration_GetDefaultExecutionLabel {
+	c_call := _m.On("GetDefaultExecutionLabel")
+	return &ClusterConfiguration_GetDefaultExecutionLabel{Call: c_call}
+}
+
+func (_m *ClusterConfiguration) OnGetDefaultExecutionLabelMatch(matchers ...interface{}) *ClusterConfiguration_GetDefaultExecutionLabel {
+	c_call := _m.On("GetDefaultExecutionLabel", matchers...)
+	return &ClusterConfiguration_GetDefaultExecutionLabel{Call: c_call}
+}
+
+// GetDefaultExecutionLabel provides a mock function with given fields:
+func (_m *ClusterConfiguration) GetDefaultExecutionLabel() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 type ClusterConfiguration_GetLabelClusterMap struct {
 	*mock.Call
 }


### PR DESCRIPTION
# TL;DR
Add option to configure a defaultExecutionLabel as fallback when using multiple execution clusters.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description

In a Flyte multi-cluster setup, we can control which cluster is used by setting "execution cluster labels" on projects/workflows. However, if an execution does not match a any label, a cluster is randomly chosen from all enabled clusters. This is not ideal if one of the clusters is in any way specialized and may only execute certain workloads.

The idea is to extend the clusters config by adding a defaultExecutionLabel as shown in this example below. If no execution label matches for an execution, the configured defaultExecutionLabel is used. This way, we can easily configure one or more default execution clusters and even apply weights on them.

This feature would be purely opt-in: If defaultExecutionLabel is not set, the original behavior of selecting a cluster at random is preserved.

```
clusters:
  defaultExecutionLabel: defaultclusters
  labelClusterMap:
    defaultclusters:
      - id: defaultcluster1
        weight: 0.5
      - id: defaultcluster2
        weight: 0.5
    specializedcluster:
      - id: specializedcluster
        weight: 1
  ...
```

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2882

## Follow-up issue
_NA_
