### PR TITLE
Add Subject to UserInfoResponse header

### DIFF
--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -178,6 +178,9 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, _ *authConfig.
 	// This option means that http requests are served with protobufs, instead of json. We always want this.
 	gwmuxOptions = append(gwmuxOptions, runtime.WithMarshalerOption("application/octet-stream", &runtime.ProtoMarshaller{}))
 
+	// This option sets subject in the user info response
+	gwmuxOptions = append(gwmuxOptions, runtime.WithForwardResponseOption(auth.GetUserInfoForwardResponseHandler()))
+
 	if cfg.Security.UseAuth {
 		// Add HTTP handlers for OIDC endpoints
 		auth.RegisterHandlers(ctx, mux, authCtx)


### PR DESCRIPTION
Signed-off-by: Andrew Dye <andrewwdye@gmail.com>

# TL;DR
Add Subject from UserInfoResponse to its header for downstream consumption. For example, when `/me` is used for [auth with the nginx ingress controller](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html), only the response headers are available.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This change simply copies `Subject` from the UserInfoResponse body to its header as `X-User-Subject` by registering a forward response handler.

For testing, verified response header in chrome with admin configured for auth.

## Tracking Issue
NA

## Follow-up issue
NA