### PR TITLE
Skip database already exists errors

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flyteorg/flyteidl v1.1.19 h1:1CtSbuFhFHwUbKdv66PqbcER01iacAJU+snh0eTsXc4=
-github.com/flyteorg/flyteidl v1.1.19/go.mod h1:SLTYz2JgIKvM5MbPVlMP7uILb65fnuuZQZFHHIEYh2U=
 github.com/flyteorg/flyteidl v1.1.21 h1:09/xqYWFdUA22bVWKLjkSzhhSJfaJmDAraczpJ/Yiis=
 github.com/flyteorg/flyteidl v1.1.21/go.mod h1:f0AFl7RFycH7+JLq2th0ReH7v+Xse+QTw4jGdIxiS8I=
 github.com/flyteorg/flyteplugins v1.0.10 h1:XBycM4aOSE/WlI8iP9vqogKGXy4FMfVCUUfzxJus/p4=
@@ -943,6 +941,7 @@ github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
 github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=

--- a/pkg/repositories/database.go
+++ b/pkg/repositories/database.go
@@ -141,9 +141,9 @@ func createPostgresDbIfNotExists(ctx context.Context, gormConfig *gorm.Config, p
 
 	if result.Error != nil {
 		if !isPgErrorWithCode(result.Error, pqDbAlreadyExistsCode) {
-			logger.Warningf(ctx, "Got DB already exists for [%v], skipping...", pgConfig.DbName)
 			return nil, result.Error
 		}
+		logger.Warningf(ctx, "Got DB already exists error for [%s], skipping...", pgConfig.DbName)
 	}
 	// Now try connecting to the db again
 	return gorm.Open(dialector, gormConfig)

--- a/pkg/repositories/database_test.go
+++ b/pkg/repositories/database_test.go
@@ -122,7 +122,7 @@ func TestIsInvalidDBPgError(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.Name, func(t *testing.T) {
-			assert.Equal(t, tc.ExpectedResult, isInvalidDBPgError(tc.Err))
+			assert.Equal(t, tc.ExpectedResult, isPgErrorWithCode(tc.Err, pqInvalidDBCode))
 		})
 	}
 }
@@ -230,7 +230,7 @@ func TestIsPgDbAlreadyExistsError(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			assert.Equal(t, tc.ExpectedResult, isPgDbAlreadyExistsError(tc.Err))
+			assert.Equal(t, tc.ExpectedResult, isPgErrorWithCode(tc.Err, pqDbAlreadyExistsCode))
 		})
 	}
 }

--- a/pkg/repositories/database_test.go
+++ b/pkg/repositories/database_test.go
@@ -196,3 +196,41 @@ func TestGetDB(t *testing.T) {
 		assert.Equal(t, "sqlite", db.Name())
 	})
 }
+
+func TestIsPgDbAlreadyExistsError(t *testing.T) {
+	// wrap error with wrappedError when testing to ensure the function checks the whole error chain
+
+	testCases := []struct {
+		Name           string
+		Err            error
+		ExpectedResult bool
+	}{
+		{
+			Name:           "nil error",
+			Err:            nil,
+			ExpectedResult: false,
+		},
+		{
+			Name:           "not a PgError",
+			Err:            &wrappedError{err: &net.OpError{Op: "connect", Err: errors.New("connection refused")}},
+			ExpectedResult: false,
+		},
+		{
+			Name:           "PgError but not already exists",
+			Err:            &wrappedError{&pgconn.PgError{Severity: "FATAL", Message: "out of memory", Code: "53200"}},
+			ExpectedResult: false,
+		},
+		{
+			Name:           "PgError and is already exists",
+			Err:            &wrappedError{&pgconn.PgError{Severity: "FATAL", Message: "database \"flyte\" does not exist", Code: "42P04"}},
+			ExpectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.ExpectedResult, isPgDbAlreadyExistsError(tc.Err))
+		})
+	}
+}


### PR DESCRIPTION
# TL;DR
When in single-binary mode, data catalog and admin both attempt to initialize the database at the same time.  Error check when getting an error back from the db create call to skip the error if the other goroutine created it in the meantime.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Spin up a local db, pause it in the function so that `createPostgresDbIfNotExists` will not return early, create the database manually, resume and inspect the error returned.  Testing was done locally with a postgres container. 

