### PR TITLE
Expose kubeclient configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type ServerConfig struct {
 
 	DataProxy                DataProxyConfig  `json:"dataProxy" pflag:",Defines data proxy configuration."`
 	ReadHeaderTimeoutSeconds int              `json:"readHeaderTimeoutSeconds" pflag:",The amount of time allowed to read request headers."`
-	KubeClientConfig         KubeClientConfig `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
+	KubeClientConfig         KubeClientConfig `json:"kubeClientConfig" pflag:",Configuration to control the Kubernetes client"`
 }
 
 type DataProxyConfig struct {
@@ -52,7 +52,7 @@ type GrpcConfig struct {
 	MaxMessageSizeBytes int  `json:"maxMessageSizeBytes" pflag:",The max size in bytes for incoming gRPC messages"`
 }
 
-// KubeClientConfig contains the configuration used by flytepropeller to configure its internal Kubernetes Client.
+// KubeClientConfig contains the configuration used by flyteadmin to configure its internal Kubernetes Client.
 type KubeClientConfig struct {
 	// QPS indicates the maximum QPS to the master from this client.
 	// If it's zero, the created RESTClient will use DefaultQPS: 5

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,8 +25,9 @@ type ServerConfig struct {
 	// Deprecated: please use auth.AppAuth.ThirdPartyConfig instead.
 	DeprecatedThirdPartyConfig authConfig.ThirdPartyConfigOptions `json:"thirdPartyConfig" pflag:",Deprecated please use auth.appAuth.thirdPartyConfig instead."`
 
-	DataProxy                DataProxyConfig `json:"dataProxy" pflag:",Defines data proxy configuration."`
-	ReadHeaderTimeoutSeconds int             `json:"readHeaderTimeoutSeconds" pflag:",The amount of time allowed to read request headers."`
+	DataProxy                DataProxyConfig  `json:"dataProxy" pflag:",Defines data proxy configuration."`
+	ReadHeaderTimeoutSeconds int              `json:"readHeaderTimeoutSeconds" pflag:",The amount of time allowed to read request headers."`
+	KubeClientConfig         KubeClientConfig `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
 }
 
 type DataProxyConfig struct {
@@ -49,6 +50,18 @@ type GrpcConfig struct {
 	Port                int  `json:"port" pflag:",On which grpc port to serve admin"`
 	ServerReflection    bool `json:"serverReflection" pflag:",Enable GRPC Server Reflection"`
 	MaxMessageSizeBytes int  `json:"maxMessageSizeBytes" pflag:",The max size in bytes for incoming gRPC messages"`
+}
+
+// KubeClientConfig contains the configuration used by flytepropeller to configure its internal Kubernetes Client.
+type KubeClientConfig struct {
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS int32 `json:"qps" pflag:",Max QPS to the master for requests to KubeAPI. 0 defaults to 5."`
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int `json:"burst" pflag:",Max burst rate for throttle. 0 defaults to 10"`
+	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
+	Timeout config.Duration `json:"timeout" pflag:",Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout."`
 }
 
 type ServerSecurityOptions struct {
@@ -97,6 +110,11 @@ var defaultServerConfig = &ServerConfig{
 		},
 	},
 	ReadHeaderTimeoutSeconds: 32, // just shy of requestTimeoutUpperBound
+	KubeClientConfig: KubeClientConfig{
+		QPS:     100,
+		Burst:   25,
+		Timeout: config.Duration{Duration: 30 * time.Second},
+	},
 }
 var serverConfig = config.MustRegisterSection(SectionKey, defaultServerConfig)
 

--- a/pkg/config/serverconfig_flags.go
+++ b/pkg/config/serverconfig_flags.go
@@ -75,8 +75,8 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "dataProxy.upload.storagePrefix"), defaultServerConfig.DataProxy.Upload.StoragePrefix, "Storage prefix to use for all upload requests.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "dataProxy.download.maxExpiresIn"), defaultServerConfig.DataProxy.Download.MaxExpiresIn.String(), "Maximum allowed expiration duration.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "readHeaderTimeoutSeconds"), defaultServerConfig.ReadHeaderTimeoutSeconds, "The amount of time allowed to read request headers.")
-	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "kube-client-config.qps"), defaultServerConfig.KubeClientConfig.QPS, "Max QPS to the master for requests to KubeAPI. 0 defaults to 5.")
-	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "kube-client-config.burst"), defaultServerConfig.KubeClientConfig.Burst, "Max burst rate for throttle. 0 defaults to 10")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kube-client-config.timeout"), defaultServerConfig.KubeClientConfig.Timeout.String(), "Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout.")
+	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "kubeClientConfig.qps"), defaultServerConfig.KubeClientConfig.QPS, "Max QPS to the master for requests to KubeAPI. 0 defaults to 5.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "kubeClientConfig.burst"), defaultServerConfig.KubeClientConfig.Burst, "Max burst rate for throttle. 0 defaults to 10")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubeClientConfig.timeout"), defaultServerConfig.KubeClientConfig.Timeout.String(), "Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout.")
 	return cmdFlags
 }

--- a/pkg/config/serverconfig_flags.go
+++ b/pkg/config/serverconfig_flags.go
@@ -75,5 +75,8 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "dataProxy.upload.storagePrefix"), defaultServerConfig.DataProxy.Upload.StoragePrefix, "Storage prefix to use for all upload requests.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "dataProxy.download.maxExpiresIn"), defaultServerConfig.DataProxy.Download.MaxExpiresIn.String(), "Maximum allowed expiration duration.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "readHeaderTimeoutSeconds"), defaultServerConfig.ReadHeaderTimeoutSeconds, "The amount of time allowed to read request headers.")
+	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "kube-client-config.qps"), defaultServerConfig.KubeClientConfig.QPS, "Max QPS to the master for requests to KubeAPI. 0 defaults to 5.")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "kube-client-config.burst"), defaultServerConfig.KubeClientConfig.Burst, "Max burst rate for throttle. 0 defaults to 10")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kube-client-config.timeout"), defaultServerConfig.KubeClientConfig.Timeout.String(), "Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout.")
 	return cmdFlags
 }

--- a/pkg/config/serverconfig_flags_test.go
+++ b/pkg/config/serverconfig_flags_test.go
@@ -449,4 +449,46 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_kube-client-config.qps", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("kube-client-config.qps", testValue)
+			if vInt32, err := cmdFlags.GetInt32("kube-client-config.qps"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vInt32), &actual.KubeClientConfig.QPS)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_kube-client-config.burst", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("kube-client-config.burst", testValue)
+			if vInt, err := cmdFlags.GetInt("kube-client-config.burst"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vInt), &actual.KubeClientConfig.Burst)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_kube-client-config.timeout", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := defaultServerConfig.KubeClientConfig.Timeout.String()
+
+			cmdFlags.Set("kube-client-config.timeout", testValue)
+			if vString, err := cmdFlags.GetString("kube-client-config.timeout"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vString), &actual.KubeClientConfig.Timeout)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/pkg/config/serverconfig_flags_test.go
+++ b/pkg/config/serverconfig_flags_test.go
@@ -449,13 +449,13 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_kube-client-config.qps", func(t *testing.T) {
+	t.Run("Test_kubeClientConfig.qps", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("kube-client-config.qps", testValue)
-			if vInt32, err := cmdFlags.GetInt32("kube-client-config.qps"); err == nil {
+			cmdFlags.Set("kubeClientConfig.qps", testValue)
+			if vInt32, err := cmdFlags.GetInt32("kubeClientConfig.qps"); err == nil {
 				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vInt32), &actual.KubeClientConfig.QPS)
 
 			} else {
@@ -463,13 +463,13 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_kube-client-config.burst", func(t *testing.T) {
+	t.Run("Test_kubeClientConfig.burst", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("kube-client-config.burst", testValue)
-			if vInt, err := cmdFlags.GetInt("kube-client-config.burst"); err == nil {
+			cmdFlags.Set("kubeClientConfig.burst", testValue)
+			if vInt, err := cmdFlags.GetInt("kubeClientConfig.burst"); err == nil {
 				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vInt), &actual.KubeClientConfig.Burst)
 
 			} else {
@@ -477,13 +477,13 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_kube-client-config.timeout", func(t *testing.T) {
+	t.Run("Test_kubeClientConfig.timeout", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := defaultServerConfig.KubeClientConfig.Timeout.String()
 
-			cmdFlags.Set("kube-client-config.timeout", testValue)
-			if vString, err := cmdFlags.GetString("kube-client-config.timeout"); err == nil {
+			cmdFlags.Set("kubeClientConfig.timeout", testValue)
+			if vString, err := cmdFlags.GetString("kubeClientConfig.timeout"); err == nil {
 				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vString), &actual.KubeClientConfig.Timeout)
 
 			} else {

--- a/pkg/executioncluster/impl/cluster_execution_target_provider.go
+++ b/pkg/executioncluster/impl/cluster_execution_target_provider.go
@@ -16,7 +16,7 @@ type clusterExecutionTargetProvider struct{}
 
 // Creates a new Execution target for a cluster based on config passed in.
 func (c *clusterExecutionTargetProvider) GetExecutionTarget(initializationErrorCounter prometheus.Counter, k8sCluster runtime.ClusterConfig) (*executioncluster.ExecutionTarget, error) {
-	kubeConf, err := flytek8s.GetRestClientConfigForCluster(k8sCluster)
+	kubeConf, err := flytek8s.GetRestClientConfig("", "", &k8sCluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flytek8s/client.go
+++ b/pkg/flytek8s/client.go
@@ -44,6 +44,11 @@ func GetRestClientConfigForCluster(cluster runtimeInterfaces.ClusterConfig) (*re
 		return nil, err
 	}
 	logger.Debugf(context.Background(), "successfully loaded kube configuration from %v", cluster)
+	if cluster.KubeClientConfig != nil {
+		kubeConfiguration.QPS = cluster.KubeClientConfig.QPS
+		kubeConfiguration.Burst = cluster.KubeClientConfig.Burst
+		kubeConfiguration.Timeout = cluster.KubeClientConfig.Timeout.Duration
+	}
 	return kubeConfiguration, nil
 }
 
@@ -70,6 +75,12 @@ func GetRestClientConfig(kubeConfig, master string,
 			return nil, errors.NewFlyteAdminErrorf(codes.Internal, "Cannot get incluster kubeconfig : %v", err.Error())
 		}
 		logger.Debug(context.Background(), "successfully loaded kube configuration from in cluster config")
+	}
+
+	if k8sCluster.KubeClientConfig != nil {
+		kubeConfiguration.QPS = k8sCluster.KubeClientConfig.QPS
+		kubeConfiguration.Burst = k8sCluster.KubeClientConfig.Burst
+		kubeConfiguration.Timeout = k8sCluster.KubeClientConfig.Timeout.Duration
 	}
 	return kubeConfiguration, nil
 }

--- a/pkg/runtime/interfaces/cluster_configuration.go
+++ b/pkg/runtime/interfaces/cluster_configuration.go
@@ -14,7 +14,7 @@ type ClusterConfig struct {
 	Endpoint         string                   `json:"endpoint"`
 	Auth             Auth                     `json:"auth"`
 	Enabled          bool                     `json:"enabled"`
-	KubeClientConfig *config.KubeClientConfig `json:"kube-client-config,omitempty"`
+	KubeClientConfig *config.KubeClientConfig `json:"kubeClientConfig,omitempty"`
 }
 
 type Auth struct {

--- a/pkg/runtime/interfaces/cluster_configuration.go
+++ b/pkg/runtime/interfaces/cluster_configuration.go
@@ -3,30 +3,18 @@ package interfaces
 import (
 	"io/ioutil"
 
-	"github.com/flyteorg/flytestdlib/config"
+	"github.com/flyteorg/flyteadmin/pkg/config"
 
 	"github.com/pkg/errors"
 )
 
-// KubeClientConfig contains the configuration used by flytepropeller to configure its internal Kubernetes Client.
-type KubeClientConfig struct {
-	// QPS indicates the maximum QPS to the master from this client.
-	// If it's zero, the created RESTClient will use DefaultQPS: 5
-	QPS float32 `json:"qps" pflag:"-,Max QPS to the master for requests to KubeAPI. 0 defaults to 5."`
-	// Maximum burst for throttle.
-	// If it's zero, the created RESTClient will use DefaultBurst: 10.
-	Burst int `json:"burst" pflag:",Max burst rate for throttle. 0 defaults to 10"`
-	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
-	Timeout config.Duration `json:"timeout" pflag:",Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout."`
-}
-
 // Holds details about a cluster used for workflow execution.
 type ClusterConfig struct {
-	Name             string            `json:"name"`
-	Endpoint         string            `json:"endpoint"`
-	Auth             Auth              `json:"auth"`
-	Enabled          bool              `json:"enabled"`
-	KubeClientConfig *KubeClientConfig `json:"kube-client-config,omitempty"`
+	Name             string                   `json:"name"`
+	Endpoint         string                   `json:"endpoint"`
+	Auth             Auth                     `json:"auth"`
+	Enabled          bool                     `json:"enabled"`
+	KubeClientConfig *config.KubeClientConfig `json:"kube-client-config,omitempty"`
 }
 
 type Auth struct {

--- a/pkg/runtime/interfaces/cluster_configuration.go
+++ b/pkg/runtime/interfaces/cluster_configuration.go
@@ -26,7 +26,7 @@ type ClusterConfig struct {
 	Endpoint         string            `json:"endpoint"`
 	Auth             Auth              `json:"auth"`
 	Enabled          bool              `json:"enabled"`
-	KubeClientConfig *KubeClientConfig `json:"kube-client-config"`
+	KubeClientConfig *KubeClientConfig `json:"kube-client-config,omitempty"`
 }
 
 type Auth struct {

--- a/pkg/runtime/interfaces/cluster_configuration.go
+++ b/pkg/runtime/interfaces/cluster_configuration.go
@@ -3,15 +3,30 @@ package interfaces
 import (
 	"io/ioutil"
 
+	"github.com/flyteorg/flytestdlib/config"
+
 	"github.com/pkg/errors"
 )
 
+// KubeClientConfig contains the configuration used by flytepropeller to configure its internal Kubernetes Client.
+type KubeClientConfig struct {
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS float32 `json:"qps" pflag:"-,Max QPS to the master for requests to KubeAPI. 0 defaults to 5."`
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int `json:"burst" pflag:",Max burst rate for throttle. 0 defaults to 10"`
+	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
+	Timeout config.Duration `json:"timeout" pflag:",Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout."`
+}
+
 // Holds details about a cluster used for workflow execution.
 type ClusterConfig struct {
-	Name     string `json:"name"`
-	Endpoint string `json:"endpoint"`
-	Auth     Auth   `json:"auth"`
-	Enabled  bool   `json:"enabled"`
+	Name             string            `json:"name"`
+	Endpoint         string            `json:"endpoint"`
+	Auth             Auth              `json:"auth"`
+	Enabled          bool              `json:"enabled"`
+	KubeClientConfig *KubeClientConfig `json:"kube-client-config"`
 }
 
 type Auth struct {


### PR DESCRIPTION
# TL;DR
Adding `KubeClientConfig` to the FlyteAdmin configuration. This can be set at the `server` level, which then serves as a default of there are multiple clusters configured. Additionally, each cluster can set this individually.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The only thing I don't like is setting `QPS` in the `KubeClientConfig` as an `int32` and then casting to `float32` when setting on the `kubeConfiguration`. This is necessary because we have to set pflags to "-" in the case of float32 because the library does not support floats, so the QPS value is not carried over.

## Tracking Issue
_NA_

## Follow-up issue
_NA_