### PR TITLE
Add configurable UTC timezone option for scheduler

### DIFF
--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -344,10 +344,15 @@ type FlyteWorkflowExecutorConfig struct {
 	// eg : 100 TPS will send at the max 100 schedule requests to admin per sec.
 	// Burst specifies burst traffic count
 	AdminRateLimit *AdminRateLimit `json:"adminRateLimit"`
+	UseUTCTz       bool            `json:"useUTCTz"`
 }
 
 func (f *FlyteWorkflowExecutorConfig) GetAdminRateLimit() *AdminRateLimit {
 	return f.AdminRateLimit
+}
+
+func (f *FlyteWorkflowExecutorConfig) GetUseUTCTz() bool {
+	return f.UseUTCTz
 }
 
 type AdminRateLimit struct {

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -344,7 +344,8 @@ type FlyteWorkflowExecutorConfig struct {
 	// eg : 100 TPS will send at the max 100 schedule requests to admin per sec.
 	// Burst specifies burst traffic count
 	AdminRateLimit *AdminRateLimit `json:"adminRateLimit"`
-	UseUTCTz       bool            `json:"useUTCTz"`
+	// Defaults to using user local timezone where the scheduler is deployed.
+	UseUTCTz bool `json:"useUTCTz"`
 }
 
 func (f *FlyteWorkflowExecutorConfig) GetAdminRateLimit() *AdminRateLimit {

--- a/scheduler/core/gocron_scheduler.go
+++ b/scheduler/core/gocron_scheduler.go
@@ -327,9 +327,13 @@ func getFixedRateDurationFromSchedule(unit admin.FixedRateUnit, fixedRateValue u
 }
 
 func NewGoCronScheduler(ctx context.Context, schedules []models.SchedulableEntity, scope promutils.Scope,
-	snapshot snapshoter.Snapshot, rateLimiter *rate.Limiter, executor executor.Executor) Scheduler {
+	snapshot snapshoter.Snapshot, rateLimiter *rate.Limiter, executor executor.Executor, useUtcTz bool) Scheduler {
 	// Create the new cron scheduler and start it off
-	c := cron.New()
+	var opts []cron.Option
+	if useUtcTz {
+		opts = append(opts, cron.WithLocation(time.UTC))
+	}
+	c := cron.New(opts...)
 	c.Start()
 	scheduler := &GoCronScheduler{
 		cron:        c,

--- a/scheduler/schedule_executor.go
+++ b/scheduler/schedule_executor.go
@@ -68,7 +68,8 @@ func (w *ScheduledExecutor) Run(ctx context.Context) error {
 	// Also Bootstrap the schedules from the snapshot
 	bootStrapCtx, bootStrapCancel := context.WithCancel(ctx)
 	defer bootStrapCancel()
-	gcronScheduler := core.NewGoCronScheduler(bootStrapCtx, schedules, w.scope, snapshot, rateLimiter, executor)
+	useUtcTz := w.workflowExecutorConfig.UseUTCTz
+	gcronScheduler := core.NewGoCronScheduler(bootStrapCtx, schedules, w.scope, snapshot, rateLimiter, executor, useUtcTz)
 	w.scheduler = gcronScheduler
 
 	// Start the go routine to write the update schedules periodically


### PR DESCRIPTION
Signed-off-by: pmahindrakar-oss <prafulla.mahindrakar@gmail.com>

# TL;DR

This maintain backward compat with existing scheduler deployment jobs and keeps them running in the local timezone.
Inorder to run the jobs in UTC timezone add this useUTCTz bool option in scheduler config



## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/3047

## Follow-up issue
_NA_
