### PR TITLE
Adding CheckAndFetchInputsForExecution on single task executions

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -575,6 +575,18 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 		return nil, nil, err
 	}
 
+	executionInputs, err := validation.CheckAndFetchInputsForExecution(
+		request.Inputs,
+		launchPlan.Spec.FixedInputs,
+		launchPlan.Closure.ExpectedInputs,
+	)
+	if err != nil {
+		logger.Debugf(ctx, "Failed to CheckAndFetchInputsForExecution with request.Inputs: %+v"+
+			"fixed inputs: %+v and expected inputs: %+v with err %v",
+			request.Inputs, launchPlan.Spec.FixedInputs, launchPlan.Closure.ExpectedInputs, err)
+		return nil, nil, err
+	}
+
 	name := util.GetExecutionName(request)
 	workflowExecutionID := core.WorkflowExecutionIdentifier{
 		Project: request.Project,
@@ -647,7 +659,7 @@ func (m *ExecutionManager) launchSingleTaskExecution(
 	}
 
 	executionParameters := workflowengineInterfaces.ExecutionParameters{
-		Inputs:              request.Inputs,
+		Inputs:              executionInputs,
 		AcceptedAt:          requestedAt,
 		Labels:              labels,
 		Annotations:         annotations,

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3903,6 +3903,18 @@ func TestCreateSingleTaskExecution(t *testing.T) {
 			}, nil
 		})
 
+	var launchplan *models.LaunchPlan
+	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetCreateCallback(func(input models.LaunchPlan) error {
+		launchplan = &input
+		return nil
+	})
+	repository.LaunchPlanRepo().(*repositoryMocks.MockLaunchPlanRepo).SetGetCallback(func(input interfaces.Identifier) (models.LaunchPlan, error) {
+		if launchplan == nil {
+			return models.LaunchPlan{}, flyteAdminErrors.NewFlyteAdminError(codes.NotFound, "launchplan not found")
+		}
+		return *launchplan, nil
+	})
+
 	mockStorage := getMockStorageForExecTest(context.Background())
 	workflowManager := NewWorkflowManager(
 		repository,
@@ -3947,45 +3959,17 @@ func TestCreateSingleTaskExecution(t *testing.T) {
 			},
 		},
 	}
-	marshaller := jsonpb.Marshaler{}
-	stringReq, ferr := marshaller.MarshalToString(&request)
-	assert.NoError(t, ferr)
-	println(fmt.Sprintf("req: %+v", stringReq))
-	_, err := execManager.CreateExecution(context.TODO(), admin.ExecutionCreateRequest{
-		Project: "flytekit",
-		Domain:  "production",
-		Name:    "singletaskexec",
-		Spec: &admin.ExecutionSpec{
-			LaunchPlan: &core.Identifier{
-				Project:      "flytekit",
-				Domain:       "production",
-				Name:         "simple_task",
-				Version:      "12345",
-				ResourceType: core.ResourceType_TASK,
-			},
-			AuthRole: &admin.AuthRole{
-				KubernetesServiceAccount: "foo",
-			},
-		},
-		Inputs: &core.LiteralMap{
-			Literals: map[string]*core.Literal{
-				"a": {
-					Value: &core.Literal_Scalar{
-						Scalar: &core.Scalar{
-							Value: &core.Scalar_Primitive{
-								Primitive: &core.Primitive{
-									Value: &core.Primitive_Integer{
-										Integer: 999,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}, time.Now())
 
+	marshaller := jsonpb.Marshaler{}
+	_, ferr := marshaller.MarshalToString(&request)
+	assert.NoError(t, ferr)
+
+	// test once to create an initial launchplan
+	_, err := execManager.CreateExecution(context.TODO(), request, time.Now())
+	assert.NoError(t, err)
+
+	// test again to ensure existing launchplan retreival works
+	_, err = execManager.CreateExecution(context.TODO(), request, time.Now())
 	assert.NoError(t, err)
 }
 

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3968,7 +3968,7 @@ func TestCreateSingleTaskExecution(t *testing.T) {
 	_, err := execManager.CreateExecution(context.TODO(), request, time.Now())
 	assert.NoError(t, err)
 
-	// test again to ensure existing launchplan retreival works
+	// test again to ensure existing launchplan retrieval works
 	_, err = execManager.CreateExecution(context.TODO(), request, time.Now())
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
# TL;DR
Currently executing a single task does not validate inputs on the auto-generated launchplan. However, an ancillary effect is the function used for this validation converts `nil` input values to an empty LiteralMap. This is important because executing `pyflyte run` on a task will call this stack and it fails because the input values are nil. This PR adds the validation to single task execution, allowing defaulted values and automatic handling of `nil` inputs.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3008

## Follow-up issue
_NA_
