### PR TITLE
Update kafka config

### DIFF
--- a/pkg/async/cloudevent/factory.go
+++ b/pkg/async/cloudevent/factory.go
@@ -64,7 +64,7 @@ func NewCloudEventsPublisher(ctx context.Context, config runtimeInterfaces.Cloud
 	case cloudEventImplementations.Kafka:
 		saramaConfig := sarama.NewConfig()
 		var err error
-		saramaConfig.Version, err = sarama.ParseKafkaVersion(config.KafkaConfig.KafkaVersion)
+		saramaConfig.Version, err = sarama.ParseKafkaVersion(config.KafkaConfig.Version)
 		if err != nil {
 			logger.Fatalf(ctx, "failed to parse kafka version, %v", err)
 			panic(err)

--- a/pkg/async/cloudevent/factory.go
+++ b/pkg/async/cloudevent/factory.go
@@ -63,15 +63,19 @@ func NewCloudEventsPublisher(ctx context.Context, config runtimeInterfaces.Cloud
 		return cloudEventImplementations.NewCloudEventsPublisher(&cloudEventImplementations.PubSubSender{Pub: publisher}, scope, config.EventsPublisherConfig.EventTypes)
 	case cloudEventImplementations.Kafka:
 		saramaConfig := sarama.NewConfig()
-		saramaConfig.Version = config.KafkaConfig.Version
+		var err error
+		saramaConfig.Version, err = sarama.ParseKafkaVersion(config.KafkaConfig.KafkaVersion)
+		if err != nil {
+			logger.Fatalf(ctx, "failed to parse kafka version, %v", err)
+			panic(err)
+		}
 		sender, err := kafka_sarama.NewSender(config.KafkaConfig.Brokers, saramaConfig, config.EventsPublisherConfig.TopicName)
 		if err != nil {
 			panic(err)
 		}
-		defer sender.Close(ctx)
 		client, err := cloudevents.NewClient(sender, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
 		if err != nil {
-			logger.Fatalf(ctx, "failed to create client, %v", err)
+			logger.Fatalf(ctx, "failed to create kafka client, %v", err)
 			panic(err)
 		}
 		return cloudEventImplementations.NewCloudEventsPublisher(&cloudEventImplementations.KafkaSender{Client: client}, scope, config.EventsPublisherConfig.EventTypes)

--- a/pkg/async/cloudevent/factory_test.go
+++ b/pkg/async/cloudevent/factory_test.go
@@ -56,10 +56,10 @@ func TestInvalidKafkaConfig(t *testing.T) {
 		Enable:                true,
 		Type:                  implementations.Kafka,
 		EventsPublisherConfig: runtimeInterfaces.EventsPublisherConfig{TopicName: "topic"},
-		KafkaConfig:           runtimeInterfaces.KafkaConfig{KafkaVersion: "0.8.2.0"},
+		KafkaConfig:           runtimeInterfaces.KafkaConfig{Version: "0.8.2.0"},
 	}
 	NewCloudEventsPublisher(context.Background(), cfg, promutils.NewTestScope())
-	cfg.KafkaConfig = runtimeInterfaces.KafkaConfig{KafkaVersion: "2.1.0"}
+	cfg.KafkaConfig = runtimeInterfaces.KafkaConfig{Version: "2.1.0"}
 	NewCloudEventsPublisher(context.Background(), cfg, promutils.NewTestScope())
 	t.Errorf("did not panic")
 }

--- a/pkg/async/cloudevent/factory_test.go
+++ b/pkg/async/cloudevent/factory_test.go
@@ -56,7 +56,10 @@ func TestInvalidKafkaConfig(t *testing.T) {
 		Enable:                true,
 		Type:                  implementations.Kafka,
 		EventsPublisherConfig: runtimeInterfaces.EventsPublisherConfig{TopicName: "topic"},
+		KafkaConfig:           runtimeInterfaces.KafkaConfig{KafkaVersion: "0.8.2.0"},
 	}
+	NewCloudEventsPublisher(context.Background(), cfg, promutils.NewTestScope())
+	cfg.KafkaConfig = runtimeInterfaces.KafkaConfig{KafkaVersion: "2.1.0"}
 	NewCloudEventsPublisher(context.Background(), cfg, promutils.NewTestScope())
 	t.Errorf("did not panic")
 }

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -1,7 +1,6 @@
 package interfaces
 
 import (
-	"github.com/Shopify/sarama"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/config"
@@ -194,12 +193,10 @@ type GCPConfig struct {
 }
 
 type KafkaConfig struct {
-	// Deprecated : The version in sarama.KafkaVersion isn't exported, so json decoder can't assign a value to it. Use KafkaVersion instead.
-	Version sarama.KafkaVersion
+	// The version of Kafka, e.g. 2.1.0, 0.8.2.0
+	Version string `json:"kafkaVersion"`
 	// kafka broker addresses
 	Brokers []string `json:"brokers"`
-	// The version of Kafka, e.g. 2.1.0, 0.8.2.0
-	KafkaVersion string `json:"kafkaVersion"`
 }
 
 // This section holds configuration for the event scheduler used to schedule workflow executions.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -194,9 +194,12 @@ type GCPConfig struct {
 }
 
 type KafkaConfig struct {
+	// Deprecated : The version in sarama.KafkaVersion isn't exported, so json decoder can't assign a value to it. Use KafkaVersion instead.
 	Version sarama.KafkaVersion
 	// kafka broker addresses
 	Brokers []string `json:"brokers"`
+	// The version of Kafka, e.g. 2.1.0, 0.8.2.0
+	KafkaVersion string
 }
 
 // This section holds configuration for the event scheduler used to schedule workflow executions.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -199,7 +199,7 @@ type KafkaConfig struct {
 	// kafka broker addresses
 	Brokers []string `json:"brokers"`
 	// The version of Kafka, e.g. 2.1.0, 0.8.2.0
-	KafkaVersion string
+	KafkaVersion string `json:"kafkaVersion"`
 }
 
 // This section holds configuration for the event scheduler used to schedule workflow executions.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -194,7 +194,7 @@ type GCPConfig struct {
 
 type KafkaConfig struct {
 	// The version of Kafka, e.g. 2.1.0, 0.8.2.0
-	Version string `json:"kafkaVersion"`
+	Version string `json:"version"`
 	// kafka broker addresses
 	Brokers []string `json:"brokers"`
 }


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Json decoder failed to decode the version in yaml file because the `version` in [sarama.KafkaVersion](https://github.com/Shopify/sarama/blob/978aadd67322a6ee5b790d700698a5ec98aa9170/utils.go#L114) isn't exported. 

Json decoder can only assign the value to the exported field. https://pkg.go.dev/encoding/json#Unmarshal

> Struct values encode as JSON objects. Each exported struct field becomes a member of the object, using the field name as the object key, unless the field is omitted for one of the reasons given below.

- Add `KafkaVersion` in the Kafka config, and use `sarama.ParseKafkaVersion` to parse it.
- Remove `sender.Close` when creating Kafka Client, which is unnecessary. It will be used when sending the event to Kafka.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
- https://github.com/flyteorg/flyte/issues/3117
- https://flyte-org.slack.com/archives/CP2HDHKE1/p1669385925148139

## Follow-up issue
_NA_
