### PR TITLE
Fix typo in launch entity rollback

### DIFF
--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -397,7 +397,7 @@ var Migrations = []*gormigrate.Migration{
 			return tx.AutoMigrate(&models.Execution{})
 		},
 		Rollback: func(tx *gorm.DB) error {
-			return tx.Model(&models.Execution{}).Migrator().DropColumn(&models.Execution{}, "launch_type")
+			return tx.Model(&models.Execution{}).Migrator().DropColumn(&models.Execution{}, "launch_entity")
 		},
 	},
 }


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Fixes typo in executions model migration rollback code introducing the launch_entity column. Sidenote: it would be terrific if gorm model fields' respective db names could be referenced programmatically 😅 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Discovered thru manual review

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3144

## Follow-up issue
_NA_
