### PR TITLE
Add signalservice http handler

### DIFF
--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -223,6 +223,11 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, _ *authConfig.
 		return nil, errors.Wrap(err, "error registering data proxy service")
 	}
 
+	err = service.RegisterSignalServiceHandlerFromEndpoint(ctx, gwmux, grpcAddress, grpcConnectionOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "error registering signal service")
+	}
+
 	mux.Handle("/", gwmux)
 
 	return mux, nil


### PR DESCRIPTION
# TL;DR
Add the HTTP handler for the SignalService.  Otherwise cannot hit the /api/v1/signals endpoint.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The gwmux is responsible for translating/forwarding http calls to the grpc server.  Copy/paste and change name of service.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/208
