### PR TITLE
Only merge system defaults when querying workflow execution config for project attributes

### DIFF
--- a/flyteadmin_config.yaml
+++ b/flyteadmin_config.yaml
@@ -6,7 +6,7 @@ server:
   httpPort: 8088
   grpcPort: 8089
   grpcServerReflection: true
-  kube-config: /Users/ytong/.flyte/state/kubeconfig
+  kube-config: /Users/ytong/.flyte/sandbox/kubeconfig
   security:
     secure: false
     useAuth: false
@@ -62,10 +62,11 @@ flyteadmin:
   useOffloadedWorkflowClosure: false
 database:
   postgres:
-    port: 5432
+    port: 30001
     username: postgres
-    host: localhost
-    dbname: flyteadmin
+    password: postgres
+    host: 127.0.0.1
+    dbname: flyte
     options: "sslmode=disable"
 scheduler:
   eventScheduler:
@@ -115,14 +116,17 @@ Logger:
   show-source: true
   level: 6
 storage:
-  type: minio
-  connection:
-    access-key: minio
-    auth-type: accesskey
-    secret-key: miniostorage
-    disable-ssl: true
-    endpoint: "http://localhost:30084"
-    region: my-region
+  type: stow
+  stow:
+    kind: s3
+    config:
+      region: us-east-1
+      disable_ssl: true
+      v2_signing: true
+      endpoint: http://localhost:30002
+      auth_type: accesskey
+      access_key_id: minio
+      secret_key: miniostorage
   signedUrl:
     stowConfigOverride:
       endpoint: http://localhost:30084

--- a/pkg/manager/impl/resources/resource_manager.go
+++ b/pkg/manager/impl/resources/resource_manager.go
@@ -213,9 +213,8 @@ func (m *ResourceManager) GetProjectAttributes(ctx context.Context, request admi
 	configLevelDefaults := m.config.GetTopLevelConfig().GetAsWorkflowExecutionConfig()
 	if err != nil {
 		ec, ok := err.(errors.FlyteAdminError)
-		if ok && ec.Code() == codes.NotFound {
+		if ok && ec.Code() == codes.NotFound && request.ResourceType == admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG {
 			// TODO: Will likely be removed after overarching settings project is done
-			// Proceed with the default CreateOrUpdate call since there's no existing model to update.
 			return &admin.ProjectAttributesGetResponse{
 				Attributes: &admin.ProjectAttributes{
 					Project: request.Project,

--- a/pkg/manager/impl/resources/resource_manager_test.go
+++ b/pkg/manager/impl/resources/resource_manager_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	runtimeInterfaces "github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 


### PR DESCRIPTION
# TL;DR
The project-level-only matchable attribute endpoint currently merges in defaults from the server config (as this was the quickest way to get things going in light of the need to expose this to the UI and the complexity of the broader settings project).  There was a bug in the [initial implementation](https://github.com/flyteorg/flyteadmin/pull/480) though - these system level defaults should only be merged when the user is querying for workflow execution configs.  This just adds a check for that.

See the original PR for more info as well.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Also update some the default config.yaml to work with the new single-binary based demo sandbox.

## Tracking Issue
Just noticed this in testing.
