### PR TITLE
Remove duplicate logic of resolveSecurityCtx in execution_manager

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -393,11 +393,8 @@ func (m *ExecutionManager) getExecutionConfig(ctx context.Context, request *admi
 	// K8sServiceAccount and  IamRole is empty then get the values from the deprecated fields.
 	resolvedAuthRole := resolveAuthRole(request, launchPlan)
 	resolvedSecurityCtx := resolveSecurityCtx(ctx, workflowExecConfig.GetSecurityContext(), resolvedAuthRole)
-	if workflowExecConfig.GetSecurityContext() == nil &&
-		(len(resolvedSecurityCtx.GetRunAs().GetK8SServiceAccount()) > 0 ||
-			len(resolvedSecurityCtx.GetRunAs().GetIamRole()) > 0) {
-		workflowExecConfig.SecurityContext = resolvedSecurityCtx
-	}
+	workflowExecConfig.SecurityContext = resolvedSecurityCtx
+
 	// Merge the application config into workflowExecConfig. If even the deprecated fields are not set
 	workflowExecConfig = util.MergeIntoExecConfig(workflowExecConfig, m.config.ApplicationConfiguration().GetTopLevelConfig())
 	// Explicitly set the security context if its nil since downstream we expect this settings to be available


### PR DESCRIPTION
# TL;DR
`resolvedSecurity` falls back to `executionConfigSecurityCtx` if exists in `func resolveSecurityCtx` ([here](https://github.com/flyteorg/flyteadmin/blob/master/pkg/manager/impl/execution_manager.go#L680)). We don't need duplicated logic [here](https://github.com/flyteorg/flyteadmin/compare/master...ByronHsu:flyteadmin:gh-rm-resolve-sc-dup-logic?expand=1#diff-9b311b663f43eccf79220bfcae3a565ad26d83532c945f39cfc1f7ba029c22e3L343).

## Type
 - [x] Refactor

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Test

```byhsu@byhsu-ld1 ~/local-repo/flyte/flyteadmin gh-master flytekit ❯ make test_unit                                       
Makefile:33: warning: overriding recipe for target `k8s_integration_execute'
boilerplate/flyte/end2end/Makefile:12: warning: ignoring old recipe for target `k8s_integration_execute'
go test -cover ./... -race
ok      github.com/flyteorg/flyteadmin/auth     1.475s  coverage: 34.6% of statements
ok      github.com/flyteorg/flyteadmin/auth/authzserver 17.421s coverage: 60.6% of statements
ok      github.com/flyteorg/flyteadmin/auth/config      0.358s  coverage: 63.6% of statements
?       github.com/flyteorg/flyteadmin/auth/interfaces  [no test files]
?       github.com/flyteorg/flyteadmin/auth/interfaces/mocks    [no test files]
?       github.com/flyteorg/flyteadmin/cmd      [no test files]
?       github.com/flyteorg/flyteadmin/cmd/entrypoints  [no test files]
?       github.com/flyteorg/flyteadmin/cmd/scheduler    [no test files]
?       github.com/flyteorg/flyteadmin/cmd/scheduler/entrypoints        [no test files]
ok      github.com/flyteorg/flyteadmin/dataproxy        0.317s  coverage: 61.8% of statements
ok      github.com/flyteorg/flyteadmin/pkg/async        0.245s  coverage: 100.0% of statements
ok      github.com/flyteorg/flyteadmin/pkg/async/cloudevent     0.214s  coverage: 78.6% of statements
ok      github.com/flyteorg/flyteadmin/pkg/async/cloudevent/implementations     0.241s  coverage: 83.3% of statements
?       github.com/flyteorg/flyteadmin/pkg/async/cloudevent/interfaces  [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/cloudevent/mocks       [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/async/events/implementations 0.218s  coverage: 45.0% of statements
?       github.com/flyteorg/flyteadmin/pkg/async/events/interfaces      [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/events/mocks   [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/async/notifications  0.229s  coverage: 18.9% of statements
ok      github.com/flyteorg/flyteadmin/pkg/async/notifications/implementations  0.295s  coverage: 72.9% of statements
?       github.com/flyteorg/flyteadmin/pkg/async/notifications/interfaces       [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/notifications/mocks    [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/schedule       [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/async/schedule/aws   0.363s  coverage: 66.7% of statements
?       github.com/flyteorg/flyteadmin/pkg/async/schedule/aws/interfaces        [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/schedule/aws/mocks     [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/schedule/interfaces    [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/schedule/mocks [no test files]
?       github.com/flyteorg/flyteadmin/pkg/async/schedule/noop  [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/clusterresource      0.528s  coverage: 33.4% of statements
ok      github.com/flyteorg/flyteadmin/pkg/clusterresource/impl 0.230s  coverage: 89.7% of statements
?       github.com/flyteorg/flyteadmin/pkg/clusterresource/interfaces   [no test files]
?       github.com/flyteorg/flyteadmin/pkg/clusterresource/mocks        [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/common       0.370s  coverage: 75.3% of statements
?       github.com/flyteorg/flyteadmin/pkg/common/mocks [no test files]
?       github.com/flyteorg/flyteadmin/pkg/common/testutils     [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/config       0.158s  coverage: 60.0% of statements
?       github.com/flyteorg/flyteadmin/pkg/data [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/data/implementations 0.138s  coverage: 62.0% of statements
?       github.com/flyteorg/flyteadmin/pkg/data/interfaces      [no test files]
?       github.com/flyteorg/flyteadmin/pkg/data/mocks   [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/errors       0.192s  coverage: 56.1% of statements
?       github.com/flyteorg/flyteadmin/pkg/executioncluster     [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/executioncluster/impl        0.711s  coverage: 59.0% of statements
?       github.com/flyteorg/flyteadmin/pkg/executioncluster/interfaces  [no test files]
?       github.com/flyteorg/flyteadmin/pkg/executioncluster/mocks       [no test files]
?       github.com/flyteorg/flyteadmin/pkg/flytek8s     [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/manager/impl 1.447s  coverage: 75.0% of statements
ok      github.com/flyteorg/flyteadmin/pkg/manager/impl/executions      0.313s  coverage: 82.2% of statements
ok      github.com/flyteorg/flyteadmin/pkg/manager/impl/resources       0.268s  coverage: 76.5% of statements
?       github.com/flyteorg/flyteadmin/pkg/manager/impl/shared  [no test files]
?       github.com/flyteorg/flyteadmin/pkg/manager/impl/testutils       [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/manager/impl/util    0.549s  coverage: 79.2% of statements
ok      github.com/flyteorg/flyteadmin/pkg/manager/impl/validation      0.326s  coverage: 88.2% of statements
?       github.com/flyteorg/flyteadmin/pkg/manager/interfaces   [no test files]
?       github.com/flyteorg/flyteadmin/pkg/manager/mocks        [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/repositories 0.214s  coverage: 39.8% of statements
ok      github.com/flyteorg/flyteadmin/pkg/repositories/config  0.212s  coverage: 3.7% of statements
ok      github.com/flyteorg/flyteadmin/pkg/repositories/errors  0.182s  coverage: 50.0% of statements
?       github.com/flyteorg/flyteadmin/pkg/repositories/gen/models      [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/repositories/gormimpl        1.544s  coverage: 80.9% of statements
?       github.com/flyteorg/flyteadmin/pkg/repositories/interfaces      [no test files]
?       github.com/flyteorg/flyteadmin/pkg/repositories/mocks   [no test files]
?       github.com/flyteorg/flyteadmin/pkg/repositories/models  [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/repositories/transformers    0.468s  coverage: 82.0% of statements
ok      github.com/flyteorg/flyteadmin/pkg/rpc  0.306s  coverage: 68.5% of statements
ok      github.com/flyteorg/flyteadmin/pkg/rpc/adminservice     0.425s  coverage: 0.8% of statements
ok      github.com/flyteorg/flyteadmin/pkg/rpc/adminservice/tests       3.349s  coverage: 100.0% of statements
ok      github.com/flyteorg/flyteadmin/pkg/rpc/adminservice/util        0.237s  coverage: 82.8% of statements
ok      github.com/flyteorg/flyteadmin/pkg/runtime      0.339s  coverage: 32.6% of statements
?       github.com/flyteorg/flyteadmin/pkg/runtime/interfaces   [no test files]
?       github.com/flyteorg/flyteadmin/pkg/runtime/interfaces/mocks     [no test files]
?       github.com/flyteorg/flyteadmin/pkg/runtime/mocks        [no test files]
?       github.com/flyteorg/flyteadmin/pkg/server       [no test files]
ok      github.com/flyteorg/flyteadmin/pkg/workflowengine/impl  0.272s  coverage: 73.1% of statements
?       github.com/flyteorg/flyteadmin/pkg/workflowengine/interfaces    [no test files]
?       github.com/flyteorg/flyteadmin/pkg/workflowengine/mocks [no test files]
ok      github.com/flyteorg/flyteadmin/plugins  0.067s  coverage: 100.0% of statements
?       github.com/flyteorg/flyteadmin/scheduler        [no test files]
ok      github.com/flyteorg/flyteadmin/scheduler/core   0.215s  coverage: 76.8% of statements
ok      github.com/flyteorg/flyteadmin/scheduler/dbapi  0.180s  coverage: 92.0% of statements
ok      github.com/flyteorg/flyteadmin/scheduler/executor       0.184s  coverage: 75.9% of statements
?       github.com/flyteorg/flyteadmin/scheduler/executor/mocks [no test files]
?       github.com/flyteorg/flyteadmin/scheduler/identifier     [no test files]
?       github.com/flyteorg/flyteadmin/scheduler/repositories   [no test files]
?       github.com/flyteorg/flyteadmin/scheduler/repositories/gormimpl  [no test files]
?       github.com/flyteorg/flyteadmin/scheduler/repositories/interfaces        [no test files]
?       github.com/flyteorg/flyteadmin/scheduler/repositories/mocks     [no test files]
?       github.com/flyteorg/flyteadmin/scheduler/repositories/models    [no test files]
ok      github.com/flyteorg/flyteadmin/scheduler/snapshoter     0.137s  coverage: 79.2% of statements
?       github.com/flyteorg/flyteadmin/tests    [no test files]
```