### PR TITLE
Don't truncate error messages when listing task executions

### DIFF
--- a/pkg/manager/impl/task_execution_manager.go
+++ b/pkg/manager/impl/task_execution_manager.go
@@ -284,6 +284,7 @@ func (m *TaskExecutionManager) ListTaskExecutions(
 		return nil, err
 	}
 
+	// Use default transformer options so that error messages shown for task execution attempts in the console sidebar show the full error stack trace.
 	taskExecutionList, err := transformers.FromTaskExecutionModels(output.TaskExecutions, transformers.DefaultExecutionTransformerOptions)
 	if err != nil {
 		logger.Debugf(ctx, "failed to transform task execution models for request [%+v] with err: %v", request, err)

--- a/pkg/manager/impl/task_execution_manager.go
+++ b/pkg/manager/impl/task_execution_manager.go
@@ -284,7 +284,7 @@ func (m *TaskExecutionManager) ListTaskExecutions(
 		return nil, err
 	}
 
-	taskExecutionList, err := transformers.FromTaskExecutionModels(output.TaskExecutions, transformers.ListExecutionTransformerOptions)
+	taskExecutionList, err := transformers.FromTaskExecutionModels(output.TaskExecutions, transformers.DefaultExecutionTransformerOptions)
 	if err != nil {
 		logger.Debugf(ctx, "failed to transform task execution models for request [%+v] with err: %v", request, err)
 		return nil, err

--- a/pkg/manager/impl/task_execution_manager_test.go
+++ b/pkg/manager/impl/task_execution_manager_test.go
@@ -618,8 +618,11 @@ func TestListTaskExecutions(t *testing.T) {
 	repository := repositoryMocks.NewMockRepository()
 
 	expectedLogs := []*core.TaskLog{{Uri: "test-log1.txt"}}
-	expectedOutputResult := &admin.TaskExecutionClosure_OutputUri{
-		OutputUri: "test-output.pb",
+	extraLongErrMsg := string(make([]byte, 2*100))
+	expectedOutputResult := &admin.TaskExecutionClosure_Error{
+		Error: &core.ExecutionError{
+			Message: extraLongErrMsg,
+		},
 	}
 	expectedClosure := &admin.TaskExecutionClosure{
 		StartedAt:    sampleTaskEventOccurredAt,


### PR DESCRIPTION
# TL;DR
Unfortunately the current behavior truncates the very useful error message shown in the sidebar for each task execution attempt.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Discovered after updating tenant internally

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3337

## Follow-up issue
_NA_
