### PR TITLE
Validate user-provided entity versions are url safe

### DIFF
--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -24,7 +24,7 @@ var entityToResourceType = map[common.Entity]core.ResourceType{
 }
 
 // See https://www.rfc-editor.org/rfc/rfc3986#section-2.2
-var reservedChars = "!*'();:@&=+$,/?#[]"
+var uriReservedChars = "!*'();:@&=+$,/?#[]"
 
 func ValidateEmptyStringField(field, fieldName string) error {
 	if field == "" {
@@ -138,7 +138,7 @@ func ValidateVersion(version string) error {
 	}
 	sanitizedVersion := url.QueryEscape(version)
 	if !strings.EqualFold(sanitizedVersion, version) {
-		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "version [%s] must be url safe, cannot contains chars [%s]", version, reservedChars)
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "version [%s] must be url safe, cannot contains chars [%s]", version, uriReservedChars)
 	}
 	return nil
 }

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -23,6 +23,9 @@ var entityToResourceType = map[common.Entity]core.ResourceType{
 	common.LaunchPlan: core.ResourceType_LAUNCH_PLAN,
 }
 
+// See https://www.rfc-editor.org/rfc/rfc3986#section-2.2
+var reservedChars = "!*'();:@&=+$,/?#[]"
+
 func ValidateEmptyStringField(field, fieldName string) error {
 	if field == "" {
 		return shared.GetMissingArgumentError(fieldName)
@@ -135,7 +138,7 @@ func ValidateVersion(version string) error {
 	}
 	sanitizedVersion := url.QueryEscape(version)
 	if !strings.EqualFold(sanitizedVersion, version) {
-		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "version [%s] must be url safe", version)
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "version [%s] must be url safe, cannot contains chars [%s]", version, reservedChars)
 	}
 	return nil
 }

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -131,6 +132,10 @@ func ValidateResourceType(resourceType core.ResourceType) error {
 func ValidateVersion(version string) error {
 	if err := ValidateEmptyStringField(version, shared.Version); err != nil {
 		return err
+	}
+	sanitizedVersion := url.QueryEscape(version)
+	if !strings.EqualFold(sanitizedVersion, version) {
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "version [%s] must be url safe", version)
 	}
 	return nil
 }

--- a/pkg/manager/impl/validation/validation_test.go
+++ b/pkg/manager/impl/validation/validation_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -177,10 +178,12 @@ func TestValidateVersion(t *testing.T) {
 
 	t.Run("url safe versions only", func(t *testing.T) {
 		assert.NoError(t, ValidateVersion("foo"))
-		reservedChars := rune("!*'();:@&=+$,/?#[]")
-		assert.NotNil(t, ValidateVersion("foo."))
-		assert.NotNil(t, ValidateVersion("foo/"))
-		assert.NotNil(t, ValidateVersion("foo/"))
+		// See https://www.rfc-editor.org/rfc/rfc3986#section-2.2
+		reservedChars := []rune("!*'();:@&=+$,/?#[]")
+		for _, reservedChar := range reservedChars {
+			invalidVersion := fmt.Sprintf("foo%c", reservedChar)
+			assert.NotNil(t, ValidateVersion(invalidVersion))
+		}
 	})
 }
 

--- a/pkg/manager/impl/validation/validation_test.go
+++ b/pkg/manager/impl/validation/validation_test.go
@@ -178,7 +178,7 @@ func TestValidateVersion(t *testing.T) {
 
 	t.Run("url safe versions only", func(t *testing.T) {
 		assert.NoError(t, ValidateVersion("Foo123"))
-		for _, reservedChar := range reservedChars {
+		for _, reservedChar := range uriReservedChars {
 			invalidVersion := fmt.Sprintf("foo%c", reservedChar)
 			assert.NotNil(t, ValidateVersion(invalidVersion))
 		}

--- a/pkg/manager/impl/validation/validation_test.go
+++ b/pkg/manager/impl/validation/validation_test.go
@@ -177,9 +177,7 @@ func TestValidateVersion(t *testing.T) {
 	assert.EqualError(t, err, "missing version")
 
 	t.Run("url safe versions only", func(t *testing.T) {
-		assert.NoError(t, ValidateVersion("foo"))
-		// See https://www.rfc-editor.org/rfc/rfc3986#section-2.2
-		reservedChars := []rune("!*'();:@&=+$,/?#[]")
+		assert.NoError(t, ValidateVersion("Foo123"))
 		for _, reservedChar := range reservedChars {
 			invalidVersion := fmt.Sprintf("foo%c", reservedChar)
 			assert.NotNil(t, ValidateVersion(invalidVersion))

--- a/pkg/manager/impl/validation/validation_test.go
+++ b/pkg/manager/impl/validation/validation_test.go
@@ -174,6 +174,14 @@ func TestValidateDescriptionEntityListRequest(t *testing.T) {
 func TestValidateVersion(t *testing.T) {
 	err := ValidateVersion("")
 	assert.EqualError(t, err, "missing version")
+
+	t.Run("url safe versions only", func(t *testing.T) {
+		assert.NoError(t, ValidateVersion("foo"))
+		reservedChars := rune("!*'();:@&=+$,/?#[]")
+		assert.NotNil(t, ValidateVersion("foo."))
+		assert.NotNil(t, ValidateVersion("foo/"))
+		assert.NotNil(t, ValidateVersion("foo/"))
+	})
 }
 
 func TestValidateListTaskRequest(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Ensures that user-provided entity version are url safe since they are used http paths to manipulate the entities and can lead to 404s when they include slashes.

Execution names, which are also user-provided and used in http paths are already [constrained](https://github.com/flyteorg/flyteadmin/blob/master/pkg/manager/impl/validation/execution_validator.go#L22) to a smaller subset of allowable chars

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Encountered with a user

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3427

## Follow-up issue
_NA_
