### PR TITLE
Tracking reasons time-series

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,3 +208,5 @@ require (
 )
 
 replace github.com/robfig/cron/v3 => github.com/unionai/cron/v3 v3.0.2-0.20210825070134-bfc34418fe84
+
+replace github.com/flyteorg/flyteidl => github.com/flyteorg/flyteidl v1.3.13-0.20230314170834-f9ca57c4d71b

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/fatih/structs v1.0.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flyteorg/flyteidl v1.3.9 h1:MHUa89yKwCz58mQC2OxTzYjr0d3fA14qKG462v+RAyk=
-github.com/flyteorg/flyteidl v1.3.9/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
+github.com/flyteorg/flyteidl v1.3.13-0.20230314170834-f9ca57c4d71b h1:yj9MgNGhIlzjKJ4hgsh1J0+cK+3Gmszoy39Z6l2V62w=
+github.com/flyteorg/flyteidl v1.3.13-0.20230314170834-f9ca57c4d71b/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
 github.com/flyteorg/flyteplugins v1.0.20 h1:8ZGN2c0iaZa3d/UmN2VYozLBRhthAIO48aD5g8Wly7s=
 github.com/flyteorg/flyteplugins v1.0.20/go.mod h1:ZbZVBxEWh8Icj1AgfNKg0uPzHHGd9twa4eWcY2Yt6xE=
 github.com/flyteorg/flytepropeller v1.1.51 h1:ITPH2Fqx+/1hKBFnfb6Rawws3VbEJ3tQ/1tQXSIXvcQ=

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -151,6 +151,15 @@ func CreateTaskExecutionModel(ctx context.Context, input CreateTaskExecutionMode
 		EventVersion: input.Request.Event.EventVersion,
 	}
 
+	if len(input.Request.Event.Reason) > 0 {
+		closure.Reasons = []*admin.Reason{
+			&admin.Reason{
+				OccurredAt: input.Request.Event.OccurredAt,
+				Message:    input.Request.Event.Reason,
+			},
+		}
+	}
+
 	eventPhase := input.Request.Event.Phase
 
 	// Different tasks may report different phases as their first event.
@@ -362,6 +371,15 @@ func UpdateTaskExecutionModel(ctx context.Context, request *admin.TaskExecutionE
 	taskExecutionClosure.UpdatedAt = request.Event.OccurredAt
 	taskExecutionClosure.Logs = mergeLogs(taskExecutionClosure.Logs, request.Event.Logs)
 	if len(request.Event.Reason) > 0 {
+		if taskExecutionClosure.Reason != request.Event.Reason {
+			taskExecutionClosure.Reasons = append(
+				taskExecutionClosure.Reasons,
+				&admin.Reason{
+					OccurredAt: request.Event.OccurredAt,
+					Message:    request.Event.Reason,
+				})
+		}
+
 		taskExecutionClosure.Reason = request.Event.Reason
 	}
 	if existingTaskPhase != core.TaskExecution_RUNNING.String() && taskExecutionModel.Phase == core.TaskExecution_RUNNING.String() {

--- a/pkg/repositories/transformers/task_execution_test.go
+++ b/pkg/repositories/transformers/task_execution_test.go
@@ -255,7 +255,13 @@ func TestCreateTaskExecutionModelQueued(t *testing.T) {
 		CreatedAt: taskEventOccurredAtProto,
 		UpdatedAt: taskEventOccurredAtProto,
 		Reason:    "Task was scheduled",
-		TaskType:  "sidecar",
+		Reasons: []*admin.Reason{
+			&admin.Reason{
+				OccurredAt: taskEventOccurredAtProto,
+				Message:    "Task was scheduled",
+			},
+		},
+		TaskType: "sidecar",
 	}
 
 	expectedClosureBytes, err := proto.Marshal(expectedClosure)
@@ -338,6 +344,8 @@ func TestCreateTaskExecutionModelRunning(t *testing.T) {
 		CustomInfo: &customInfo,
 	}
 
+	t.Logf("expected %+v %+v\n", expectedClosure.Reason, expectedClosure.Reasons)
+
 	expectedClosureBytes, err := proto.Marshal(expectedClosure)
 	assert.Nil(t, err)
 
@@ -386,6 +394,13 @@ func TestUpdateTaskExecutionModelRunningToFailed(t *testing.T) {
 		CustomInfo: transformMapToStructPB(t, map[string]string{
 			"key1": "value1",
 		}),
+		Reason: "Task was scheduled",
+		Reasons: []*admin.Reason{
+			&admin.Reason{
+				OccurredAt: taskEventOccurredAtProto,
+				Message:    "Task was scheduled",
+			},
+		},
 	}
 
 	closureBytes, err := proto.Marshal(existingClosure)
@@ -481,6 +496,16 @@ func TestUpdateTaskExecutionModelRunningToFailed(t *testing.T) {
 			"key1": "value1 updated",
 		}),
 		Reason: "task failed",
+		Reasons: []*admin.Reason{
+			&admin.Reason{
+				OccurredAt: taskEventOccurredAtProto,
+				Message:    "Task was scheduled",
+			},
+			&admin.Reason{
+				OccurredAt: occuredAtProto,
+				Message:    "task failed",
+			},
+		},
 	}
 
 	expectedClosureBytes, err := proto.Marshal(expectedClosure)


### PR DESCRIPTION
DO NOT MERGE waiting on PRs:
https://github.com/flyteorg/flyteidl/pull/382

# TL;DR
This PR populates the new `Reasons` field on the `TaskExecutionClosure` to track a reason time-series. This will be very useful in improving visualizations by tracking the reason for task phase transitions and updates.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/discussions/3429

## Follow-up issue
_NA_
