### PR TITLE
Enrich TerminateExecution error to tell propeller the execution already terminated

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -1644,8 +1644,9 @@ func (m *ExecutionManager) TerminateExecution(
 		logger.Infof(ctx, "couldn't find execution [%+v] to save termination cause", request.Id)
 		return nil, err
 	}
+
 	if common.IsExecutionTerminal(core.WorkflowExecution_Phase(core.WorkflowExecution_Phase_value[executionModel.Phase])) {
-		return nil, errors.NewFlyteAdminError(codes.PermissionDenied, "Cannot abort an already terminate workflow execution")
+		return nil, errors.NewAlreadyInTerminalStateError(ctx, "Cannot abort an already terminate workflow execution", executionModel.Phase)
 	}
 
 	err = transformers.SetExecutionAborting(&executionModel, request.Cause, getUser(ctx))
@@ -1653,6 +1654,7 @@ func (m *ExecutionManager) TerminateExecution(
 		logger.Debugf(ctx, "failed to add abort metadata for execution [%+v] with err: %v", request.Id, err)
 		return nil, err
 	}
+
 	err = m.db.ExecutionRepo().Update(ctx, executionModel)
 	if err != nil {
 		logger.Debugf(ctx, "failed to save abort cause for terminated execution: %+v with err: %v", request.Id, err)

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3231,7 +3231,7 @@ func TestTerminateExecution_AlreadyTerminated(t *testing.T) {
 	assert.Nil(t, resp)
 	s, ok := status.FromError(err)
 	assert.True(t, ok)
-	assert.Equal(t, codes.PermissionDenied, s.Code())
+	assert.Equal(t, codes.FailedPrecondition, s.Code())
 }
 
 func TestGetExecutionData(t *testing.T) {


### PR DESCRIPTION
# TL;DR
`TerminateExecution` error when a workflow is already in terminal state is `PermissionDenied`. This changes it to return `PreconditionFailed` w/ specific grpc status message.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/3582
