### PR TITLE
Add migration to turn `parent_id` column into `bigint` only if necessary

### DIFF
--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -697,37 +697,19 @@ var NoopMigrations = []*gormigrate.Migration{
 		},
 	},
 	{
-		ID: "pg-2023-05-02-fix-parentid-type",
+		// This migration handles the necessary setup to change the type of the `parent_id` column in the node_executions table.
+		ID: "pg-2023-05-02-fix-parentid-type-phase-1",
 		Migrate: func(tx *gorm.DB) error {
-			// This migration only applies if dialect is postgres
-			if tx.Dialector.Name() != "postgres" {
-				return nil
-			}
-			// Start transaction
-			tx1 := tx.Begin()
-			defer func() {
-				if r := recover(); r != nil {
-					tx1.Rollback()
-				}
-			}()
-
-			// We should only apply this migration in case the type of the parent_id column is integer
-			var columnType string
-			query := `
-			SELECT data_type
-			FROM information_schema.columns
-			WHERE table_name = ? AND column_name = ?;
-			`
-			err := tx1.Raw(query, "node_executions", "parent_id").Scan(&columnType).Error
+			shouldMigrate, err := shouldApplyFixParentidMigration(tx)
 			if err != nil {
 				return err
 			}
-			if columnType == "bigint" {
+			if !shouldMigrate {
 				return nil
 			}
 
 			// Alter table and add new column
-			if err := tx1.Exec("ALTER TABLE node_executions ADD COLUMN new_parent_id BIGINT;").Error; err != nil {
+			if err := tx.Exec("ALTER TABLE node_executions ADD COLUMN new_parent_id BIGINT;").Error; err != nil {
 				return err
 			}
 
@@ -741,19 +723,55 @@ var NoopMigrations = []*gormigrate.Migration{
 			END
 			$BODY$ LANGUAGE PLPGSQL;
 			`
-			if err := tx1.Exec(triggerFunction).Error; err != nil {
+			if err := tx.Exec(triggerFunction).Error; err != nil {
 				return err
 			}
 
 			// Create trigger
-			if err := tx1.Exec("CREATE TRIGGER set_new_parent_id_trigger BEFORE INSERT OR UPDATE ON node_executions FOR EACH ROW EXECUTE PROCEDURE set_new_parent_id();").Error; err != nil {
+			if err := tx.Exec("CREATE TRIGGER set_new_parent_id_trigger BEFORE INSERT OR UPDATE ON node_executions FOR EACH ROW EXECUTE PROCEDURE set_new_parent_id();").Error; err != nil {
 				return err
 			}
 
 			// Update table
-			if err := tx1.Exec("UPDATE node_executions SET new_parent_id = parent_id WHERE parent_id is not null;").Error; err != nil {
+			if err := tx.Exec("UPDATE node_executions SET new_parent_id = parent_id WHERE parent_id is not null;").Error; err != nil {
 				return err
 			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Drop trigger and function
+			if err := tx.Exec("DROP TRIGGER IF EXISTS set_new_parent_id_trigger ON node_executions;").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("DROP FUNCTION IF EXISTS set_new_parent_id();").Error; err != nil {
+				return err
+			}
+			// Drop column iff exists
+			if err := tx.Exec("ALTER TABLE node_executions DROP COLUMN IF EXISTS new_parent_id;").Error; err != nil {
+				return err
+			}
+			return nil
+		},
+	},
+	{
+		// This migration actually changes the type of the `parent_id` column in the node_executions table in a transaction.
+		ID: "pg-2023-05-02-fix-parentid-type-phase-2",
+		Migrate: func(tx *gorm.DB) error {
+			shouldMigrate, err := shouldApplyFixParentidMigration(tx)
+			if err != nil {
+				return err
+			}
+			if !shouldMigrate {
+				return nil
+			}
+
+			// Start transaction
+			tx1 := tx.Begin()
+			defer func() {
+				if r := recover(); r != nil {
+					tx1.Rollback()
+				}
+			}()
 
 			// Lock table
 			if err := tx1.Exec("LOCK TABLE node_executions IN EXCLUSIVE MODE;").Error; err != nil {
@@ -766,6 +784,7 @@ var NoopMigrations = []*gormigrate.Migration{
 				tx1.Rollback()
 				return err
 			}
+
 			if err := tx1.Exec("CREATE INDEX idx_node_executions_parent_id ON public.node_executions USING btree (new_parent_id);").Error; err != nil {
 				tx1.Rollback()
 				return err
@@ -1065,4 +1084,29 @@ func alterTableColumnType(db *sql.DB, columnName, columnType string) error {
 		}
 	}
 	return nil
+}
+
+func shouldApplyFixParentidMigration(db *gorm.DB) (bool, error) {
+	// This only applies to postgres and in the case of the node_executions table contains a
+	// column named parent_id of type `integer` instead of `bigint`.
+	if db.Dialector.Name() != "postgres" {
+		return false, nil
+	}
+
+	// We should only apply this migration in case the type of the parent_id column is integer
+	var columnType string
+	query := `
+	SELECT data_type
+	FROM information_schema.columns
+	WHERE table_name = ? AND column_name = ?;
+	`
+	err := db.Raw(query, "node_executions", "parent_id").Scan(&columnType).Error
+	if err != nil {
+		return false, err
+	}
+	if columnType == "bigint" {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/repositories/config/migrations_test.go
+++ b/pkg/repositories/config/migrations_test.go
@@ -32,3 +32,20 @@ func GetDbForTest(t *testing.T) *gorm.DB {
 	}
 	return db
 }
+
+func TestShouldApplyFixParentidMigration(t *testing.T) {
+	gormDb := GetDbForTest(t)
+	GlobalMock := mocket.Catcher.Reset()
+	GlobalMock.Logging = true
+	query := GlobalMock.NewMock()
+	query.WithQuery(`
+	SELECT data_type
+	FROM information_schema.columns
+	WHERE table_name = $1 AND column_name = $2;
+	`)
+
+	shouldApply, err := shouldApplyFixParentidMigration(gormDb)
+	assert.True(t, shouldApply)
+	assert.True(t, query.Triggered)
+	assert.NoError(t, err)
+}

--- a/pkg/repositories/config/migrations_test.go
+++ b/pkg/repositories/config/migrations_test.go
@@ -5,6 +5,7 @@ import (
 
 	mocket "github.com/Selvatico/go-mocket"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/mysql"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -31,6 +32,14 @@ func GetDbForTest(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to open mock db with err %v", err)
 	}
 	return db
+}
+
+func TestShouldApplyFixParentidMigrationMysql(t *testing.T) {
+	mocket.Catcher.Register()
+	gormDb, _ := gorm.Open(mysql.New(mysql.Config{DriverName: mocket.DriverName}))
+	shouldApply, err := shouldApplyFixParentidMigration(gormDb)
+	assert.False(t, shouldApply)
+	assert.NoError(t, err)
 }
 
 func TestShouldApplyFixParentidMigration(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Migration to change parent_id type only if necessary

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
[This](http://zemanta.github.io/2021/08/25/column-migration-from-int-to-bigint-in-postgresql/) blog post has a suggestion on how to run a postgres migration to change a column type from int to bigint without a lot of downtime.

I turned that into two gorm migrations. And tested extensively both on sandbox and in a real production table in RDS. The happy path works, but more testing is needed.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
