### PR TITLE
Retract v1.1.94 from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,7 @@ require (
 )
 
 replace github.com/robfig/cron/v3 => github.com/unionai/cron/v3 v3.0.2-0.20220915080349-5790c370e63a
+
+// Retracted versions
+// This was published in error when attempting to create 1.5.1 Flyte release.
+retract v1.1.94


### PR DESCRIPTION
Retract 1.1.94 - This was published in error from https://github.com/flyteorg/flyteadmin/pull/560