### PR TITLE
Remove single task execution default timeout

### DIFF
--- a/pkg/manager/impl/util/single_task_execution.go
+++ b/pkg/manager/impl/util/single_task_execution.go
@@ -26,7 +26,6 @@ const maxNodeIDLength = 63
 var defaultRetryStrategy = core.RetryStrategy{
 	Retries: 3,
 }
-var defaultTimeout = ptypes.DurationProto(24 * time.Hour)
 
 const systemNamePrefix = ".flytegen.%s"
 
@@ -102,7 +101,6 @@ func CreateOrGetWorkflowModel(
 						Metadata: &core.NodeMetadata{
 							Name:    generateNodeNameFromTask(taskIdentifier.Name),
 							Retries: &defaultRetryStrategy,
-							Timeout: defaultTimeout,
 						},
 						Inputs: generateBindings(*task.Closure.CompiledTask.Template.Interface.Inputs, noInputNodeID),
 						Target: &core.Node_TaskNode{

--- a/pkg/manager/impl/util/single_task_execution.go
+++ b/pkg/manager/impl/util/single_task_execution.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/flyteorg/flyteadmin/pkg/errors"
@@ -17,7 +16,6 @@ import (
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/logger"
-	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/codes"
 )
 


### PR DESCRIPTION
# TL;DR
Currently single task execution imposes a `24h` default deadline on the node when constructing a default workflow. We recently set the default workflow and node deadlines to `0s` because users unexpectedly saw executions terminated based on deadlines. We should address this similarly.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3642

## Follow-up issue
_NA_
