### PR TITLE
Tiny url improvements

### DIFF
--- a/dataproxy/service.go
+++ b/dataproxy/service.go
@@ -396,13 +396,13 @@ func (s Service) GetData(ctx context.Context, req *service.GetDataRequest) (
 	}
 
 	if executions.NodeExecID != nil {
-		return s.GetDataFromNodeExecution(ctx, *executions.NodeExecID, executions.IOType, executions.OutputName)
+		return s.GetDataFromNodeExecution(ctx, *executions.NodeExecID, executions.IOType, executions.LiteralName)
 	} else if executions.PartialTaskExecID != nil {
 		taskExecID, err := s.GetCompleteTaskExecutionID(ctx, *executions.PartialTaskExecID)
 		if err != nil {
 			return nil, err
 		}
-		return s.GetDataFromTaskExecution(ctx, *taskExecID, executions.IOType, executions.OutputName)
+		return s.GetDataFromTaskExecution(ctx, *taskExecID, executions.IOType, executions.LiteralName)
 	}
 
 	return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to parse get data request %v", req)

--- a/dataproxy/service.go
+++ b/dataproxy/service.go
@@ -258,6 +258,25 @@ func (s Service) validateResolveArtifactRequest(req *service.GetDataRequest) err
 	return nil
 }
 
+// GetCompleteTaskExecutionID returns the task execution identifier for the task execution with the Task ID filled in.
+// The one coming from the node execution doesn't have this as this is not data encapsulated in the flyte url.
+func (s Service) GetCompleteTaskExecutionID(ctx context.Context, taskExecID core.TaskExecutionIdentifier) (*core.TaskExecutionIdentifier, error) {
+
+	taskExecs, err := s.taskExecutionManager.ListTaskExecutions(ctx, admin.TaskExecutionListRequest{
+		NodeExecutionId: taskExecID.GetNodeExecutionId(),
+		Limit:           1,
+		Filters:         fmt.Sprintf("eq(retry_attempt,%s)", strconv.Itoa(int(taskExecID.RetryAttempt))),
+	})
+	if err != nil {
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to list task executions [%v]. Error: %v", taskExecID, err)
+	}
+	if len(taskExecs.TaskExecutions) == 0 {
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "no task executions were listed [%v]. Error: %v", taskExecID, err)
+	}
+	taskExec := taskExecs.TaskExecutions[0]
+	return taskExec.Id, nil
+}
+
 func (s Service) GetTaskExecutionID(ctx context.Context, attempt int, nodeExecID core.NodeExecutionIdentifier) (*core.TaskExecutionIdentifier, error) {
 	taskExecs, err := s.taskExecutionManager.ListTaskExecutions(ctx, admin.TaskExecutionListRequest{
 		NodeExecutionId: &nodeExecID,
@@ -274,66 +293,61 @@ func (s Service) GetTaskExecutionID(ctx context.Context, attempt int, nodeExecID
 	return taskExec.Id, nil
 }
 
-func (s Service) GetData(ctx context.Context, req *service.GetDataRequest) (
+func (s Service) GetDataFromNodeExecution(ctx context.Context, nodeExecID core.NodeExecutionIdentifier, ioType common.ArtifactType, name string) (
 	*service.GetDataResponse, error) {
 
-	logger.Debugf(ctx, "resolving flyte url query: %s", req.GetFlyteUrl())
-	err := s.validateResolveArtifactRequest(req)
-	if err != nil {
-		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to validate resolve artifact request. Error: %v", err)
-	}
-
-	nodeExecID, attempt, ioType, err := common.ParseFlyteURL(req.GetFlyteUrl())
-	if err != nil {
-		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to parse artifact url Error: %v", err)
-	}
-
-	// Get the data location, then decide how/where to fetch it from
-	if attempt == nil {
-		resp, err := s.nodeExecutionManager.GetNodeExecutionData(ctx, admin.NodeExecutionGetDataRequest{
-			Id: &nodeExecID,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		var lm *core.LiteralMap
-		if ioType == common.ArtifactTypeI {
-			lm = resp.FullInputs
-		} else if ioType == common.ArtifactTypeO {
-			lm = resp.FullOutputs
-		} else {
-			// Assume deck, and create a download link request
-			dlRequest := service.CreateDownloadLinkRequest{
-				ArtifactType: service.ArtifactType_ARTIFACT_TYPE_DECK,
-				Source:       &service.CreateDownloadLinkRequest_NodeExecutionId{NodeExecutionId: &nodeExecID},
-			}
-			resp, err := s.CreateDownloadLink(ctx, &dlRequest)
-			if err != nil {
-				return nil, err
-			}
-			return &service.GetDataResponse{
-				Data: &service.GetDataResponse_PreSignedUrls{
-					PreSignedUrls: resp.PreSignedUrls,
-				},
-			}, nil
-		}
-
-		return &service.GetDataResponse{
-			Data: &service.GetDataResponse_LiteralMap{
-				LiteralMap: lm,
-			},
-		}, nil
-	}
-	// Rest of the logic handles task attempt lookups
-	var lm *core.LiteralMap
-	taskExecID, err := s.GetTaskExecutionID(ctx, *attempt, nodeExecID)
+	resp, err := s.nodeExecutionManager.GetNodeExecutionData(ctx, admin.NodeExecutionGetDataRequest{
+		Id: &nodeExecID,
+	})
 	if err != nil {
 		return nil, err
 	}
 
+	var lm *core.LiteralMap
+	if ioType == common.ArtifactTypeI {
+		lm = resp.FullInputs
+	} else if ioType == common.ArtifactTypeO {
+		lm = resp.FullOutputs
+	} else {
+		// Assume deck, and create a download link request
+		dlRequest := service.CreateDownloadLinkRequest{
+			ArtifactType: service.ArtifactType_ARTIFACT_TYPE_DECK,
+			Source:       &service.CreateDownloadLinkRequest_NodeExecutionId{NodeExecutionId: &nodeExecID},
+		}
+		resp, err := s.CreateDownloadLink(ctx, &dlRequest)
+		if err != nil {
+			return nil, err
+		}
+		return &service.GetDataResponse{
+			Data: &service.GetDataResponse_PreSignedUrls{
+				PreSignedUrls: resp.PreSignedUrls,
+			},
+		}, nil
+	}
+
+	if name != "" {
+		if literal, ok := lm.Literals[name]; ok {
+			return &service.GetDataResponse{
+				Data: &service.GetDataResponse_Literal{
+					Literal: literal,
+				},
+			}, nil
+		}
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "name [%v] not found in node execution [%v]", name, nodeExecID)
+	}
+	return &service.GetDataResponse{
+		Data: &service.GetDataResponse_LiteralMap{
+			LiteralMap: lm,
+		},
+	}, nil
+}
+
+func (s Service) GetDataFromTaskExecution(ctx context.Context, taskExecID core.TaskExecutionIdentifier, ioType common.ArtifactType, name string) (
+	*service.GetDataResponse, error) {
+
+	var lm *core.LiteralMap
 	reqT := admin.TaskExecutionGetDataRequest{
-		Id: taskExecID,
+		Id: &taskExecID,
 	}
 	resp, err := s.taskExecutionManager.GetTaskExecutionData(ctx, reqT)
 	if err != nil {
@@ -347,11 +361,51 @@ func (s Service) GetData(ctx context.Context, req *service.GetDataRequest) (
 	} else {
 		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "deck type cannot be specified with a retry attempt, just use the node instead")
 	}
+
+	if name != "" {
+		if literal, ok := lm.Literals[name]; ok {
+			return &service.GetDataResponse{
+				Data: &service.GetDataResponse_Literal{
+					Literal: literal,
+				},
+			}, nil
+		}
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "name [%v] not found in task execution [%v]", name, taskExecID)
+	}
+
 	return &service.GetDataResponse{
 		Data: &service.GetDataResponse_LiteralMap{
 			LiteralMap: lm,
 		},
 	}, nil
+
+}
+
+func (s Service) GetData(ctx context.Context, req *service.GetDataRequest) (
+	*service.GetDataResponse, error) {
+
+	logger.Debugf(ctx, "resolving flyte url query: %s", req.GetFlyteUrl())
+	err := s.validateResolveArtifactRequest(req)
+	if err != nil {
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to validate resolve artifact request. Error: %v", err)
+	}
+
+	executions, err := common.ParseFlyteURLToExecution(req.GetFlyteUrl())
+	if err != nil {
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to parse artifact url Error: %v", err)
+	}
+
+	if executions.NodeExecID != nil {
+		return s.GetDataFromNodeExecution(ctx, *executions.NodeExecID, executions.IOType, executions.OutputName)
+	} else if executions.PartialTaskExecID != nil {
+		taskExecID, err := s.GetCompleteTaskExecutionID(ctx, *executions.PartialTaskExecID)
+		if err != nil {
+			return nil, err
+		}
+		return s.GetDataFromTaskExecution(ctx, *taskExecID, executions.IOType, executions.OutputName)
+	}
+
+	return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "failed to parse get data request %v", req)
 }
 
 func NewService(cfg config.DataProxyConfig,

--- a/dataproxy/service_test.go
+++ b/dataproxy/service_test.go
@@ -274,6 +274,38 @@ func TestService_GetData(t *testing.T) {
 		})
 		assert.Error(t, err)
 	})
+
+	t.Run("get individual literal without retry attempt", func(t *testing.T) {
+		res, err := s.GetData(context.Background(), &service.GetDataRequest{
+			FlyteUrl: "flyte://v1/proj/dev/wfexecid/n0-d0/i/input",
+		})
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(inputsLM.GetLiterals()["input"], res.GetLiteral()))
+		assert.Nil(t, res.GetPreSignedUrls())
+	})
+
+	t.Run("get individual literal with a retry attempt", func(t *testing.T) {
+		res, err := s.GetData(context.Background(), &service.GetDataRequest{
+			FlyteUrl: "flyte://v1/proj/dev/wfexecid/n0-d0/5/o/output",
+		})
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(outputsLM.GetLiterals()["output"], res.GetLiteral()))
+		assert.Nil(t, res.GetPreSignedUrls())
+	})
+
+	t.Run("error requesting missing name without retry attempt", func(t *testing.T) {
+		_, err := s.GetData(context.Background(), &service.GetDataRequest{
+			FlyteUrl: "flyte://v1/proj/dev/wfexecid/n0-d0/i/o5",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("error requesting missing name with a retry attempt", func(t *testing.T) {
+		_, err := s.GetData(context.Background(), &service.GetDataRequest{
+			FlyteUrl: "flyte://v1/proj/dev/wfexecid/n0-d0/5/o/o1",
+		})
+		assert.Error(t, err)
+	})
 }
 
 func TestService_Error(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.8.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/evanphx/json-patch v4.12.0+incompatible
-	github.com/flyteorg/flyteidl v1.5.5
+	github.com/flyteorg/flyteidl v1.5.6-0.20230516201101-8c154192e13b
 	github.com/flyteorg/flyteplugins v1.0.56
 	github.com/flyteorg/flytepropeller v1.1.87
 	github.com/flyteorg/flytestdlib v1.0.15
@@ -213,5 +213,3 @@ replace github.com/robfig/cron/v3 => github.com/unionai/cron/v3 v3.0.2-0.2022091
 // Retracted versions
 // This was published in error when attempting to create 1.5.1 Flyte release.
 retract v1.1.94
-
-replace github.com/flyteorg/flyteidl => ../flyteidl

--- a/go.mod
+++ b/go.mod
@@ -213,3 +213,5 @@ replace github.com/robfig/cron/v3 => github.com/unionai/cron/v3 v3.0.2-0.2022091
 // Retracted versions
 // This was published in error when attempting to create 1.5.1 Flyte release.
 retract v1.1.94
+
+replace github.com/flyteorg/flyteidl => ../flyteidl

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.8.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/evanphx/json-patch v4.12.0+incompatible
-	github.com/flyteorg/flyteidl v1.5.6-0.20230516201101-8c154192e13b
+	github.com/flyteorg/flyteidl v1.5.6
 	github.com/flyteorg/flyteplugins v1.0.56
 	github.com/flyteorg/flytepropeller v1.1.87
 	github.com/flyteorg/flytestdlib v1.0.15

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/flyteorg/flyteidl v1.5.5 h1:tNNhuXPog4atAMSGE2kyAg6JzYy1TvjqrrQeh1EZV
 github.com/flyteorg/flyteidl v1.5.5/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
 github.com/flyteorg/flyteidl v1.5.6-0.20230516201101-8c154192e13b h1:0lazboZbsmN/x2N/QYK9dh/eC6MQbDLkvI46wlXew6Y=
 github.com/flyteorg/flyteidl v1.5.6-0.20230516201101-8c154192e13b/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
+github.com/flyteorg/flyteidl v1.5.6 h1:fpNgJ1xd9L11qTJ4G/CZuba0NV9czPInGuR1T5lFPkY=
+github.com/flyteorg/flyteidl v1.5.6/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
 github.com/flyteorg/flyteplugins v1.0.56 h1:kBTDgTpdSi7wcptk4cMwz5vfh1MU82VaUMMboe1InXw=
 github.com/flyteorg/flyteplugins v1.0.56/go.mod h1:aFCKSn8TPzxSAILIiogHtUnHlUCN9+y6Vf+r9R4KZDU=
 github.com/flyteorg/flytepropeller v1.1.87 h1:Px7ASDjrWyeVrUb15qXmhw9QK7xPcFjL5Yetr2P6iGM=

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.5.5 h1:tNNhuXPog4atAMSGE2kyAg6JzYy1TvjqrrQeh1EZVHs=
 github.com/flyteorg/flyteidl v1.5.5/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
+github.com/flyteorg/flyteidl v1.5.6-0.20230516201101-8c154192e13b h1:0lazboZbsmN/x2N/QYK9dh/eC6MQbDLkvI46wlXew6Y=
+github.com/flyteorg/flyteidl v1.5.6-0.20230516201101-8c154192e13b/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
 github.com/flyteorg/flyteplugins v1.0.56 h1:kBTDgTpdSi7wcptk4cMwz5vfh1MU82VaUMMboe1InXw=
 github.com/flyteorg/flyteplugins v1.0.56/go.mod h1:aFCKSn8TPzxSAILIiogHtUnHlUCN9+y6Vf+r9R4KZDU=
 github.com/flyteorg/flytepropeller v1.1.87 h1:Px7ASDjrWyeVrUb15qXmhw9QK7xPcFjL5Yetr2P6iGM=

--- a/pkg/common/flyte_url.go
+++ b/pkg/common/flyte_url.go
@@ -22,7 +22,10 @@ const (
 	ArtifactTypeD                      // deck
 )
 
-var re = regexp.MustCompile("flyte://v1/(?P<project>[a-zA-Z0-9_-]+)/(?P<domain>[a-zA-Z0-9_-]+)/(?P<exec>[a-zA-Z0-9_-]+)/(?P<node>[a-zA-Z0-9_-]+)(?:/(?P<attempt>[0-9]+))?/(?P<artifactType>[iod])$")
+var re = regexp.MustCompile("flyte://v1/(?P<project>[a-zA-Z0-9_-]+)/(?P<domain>[a-zA-Z0-9_-]+)/(?P<exec>[a-zA-Z0-9_-]+)/(?P<node>[a-zA-Z0-9_-]+)(?:/(?P<attempt>[0-9]+))?/(?P<IOType>[iod])$")
+
+// todo: add input
+var reSpecificOutput = regexp.MustCompile("flyte://v1/(?P<project>[a-zA-Z0-9_-]+)/(?P<domain>[a-zA-Z0-9_-]+)/(?P<exec>[a-zA-Z0-9_-]+)/(?P<node>[a-zA-Z0-9_-]+)(?:/(?P<attempt>[0-9]+))?/(?P<IOType>[io])/(?P<OutputName>[a-zA-Z0-9_-]+)$")
 
 func MatchRegex(reg *regexp.Regexp, input string) map[string]string {
 	names := reg.SubexpNames()
@@ -37,10 +40,93 @@ func MatchRegex(reg *regexp.Regexp, input string) map[string]string {
 	return dict
 }
 
-func ParseFlyteURL(flyteURL string) (core.NodeExecutionIdentifier, *int, ArtifactType, error) {
-	// flyteURL is of the form flyte://v1/project/domain/execution_id/node_id/attempt/[iod]
+type ParsedExecution struct {
+	// Returned when the user does not request a specific attempt
+	NodeExecID *core.NodeExecutionIdentifier
+
+	// This is returned in the case where the user requested a specific attempt. But the TaskID portion of this
+	// will be empty
+	PartialTaskExecID *core.TaskExecutionIdentifier
+
+	// Assume always an output for now, can add support for inputs if required
+	OutputName string
+
+	IOType ArtifactType
+}
+
+func tryMatches(flyteURL string) map[string]string {
+	var matches map[string]string
+
+	if matches = MatchRegex(re, flyteURL); len(matches) > 0 {
+		return matches
+	} else if matches = MatchRegex(reSpecificOutput, flyteURL); len(matches) > 0 {
+		return matches
+	}
+	return nil
+}
+
+func ParseFlyteURLToExecution(flyteURL string) (ParsedExecution, error) {
+	// flyteURL can be of the following forms
+	//  flyte://v1/project/domain/execution_id/node_id/attempt/[iod]
+	//  flyte://v1/project/domain/execution_id/node_id/attempt/[io]/output_name
+	//  flyte://v1/project/domain/execution_id/node_id/[io]/output_name
+	//  flyte://v1/project/domain/execution_id/node_id/[iod]
+
 	// where i stands for inputs.pb o for outputs.pb and d for the flyte deck
 	// If the retry attempt is missing, the io requested is assumed to be for the node instead of the task execution
+
+	matches := tryMatches(flyteURL)
+	if matches == nil {
+		return ParsedExecution{}, fmt.Errorf("failed to parse [%s]", flyteURL)
+	}
+
+	proj := matches["project"]
+	domain := matches["domain"]
+	executionID := matches["exec"]
+	nodeID := matches["node"]
+	ioType, err := ArtifactTypeString(matches["IOType"])
+	if err != nil {
+		return ParsedExecution{}, err
+	}
+	outputName := matches["OutputName"] // may be empty
+
+	// node and task level outputs
+	nodeExecID := core.NodeExecutionIdentifier{
+		NodeId: nodeID,
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: proj,
+			Domain:  domain,
+			Name:    executionID,
+		},
+	}
+
+	// if attempt is there, that means a task execution
+	if attempt := matches["attempt"]; len(attempt) > 0 {
+		a, err := strconv.Atoi(attempt)
+		if err != nil {
+			return ParsedExecution{}, fmt.Errorf("failed to parse attempt [%v], %v", attempt, err)
+		}
+		taskExecID := core.TaskExecutionIdentifier{
+			NodeExecutionId: &nodeExecID,
+			// checking for overflow here is probably unreasonable
+			RetryAttempt: uint32(a),
+		}
+		return ParsedExecution{
+			PartialTaskExecID: &taskExecID,
+			IOType:            ioType,
+			OutputName:        outputName,
+		}, nil
+	}
+
+	return ParsedExecution{
+		NodeExecID: &nodeExecID,
+		IOType:     ioType,
+		OutputName: outputName,
+	}, nil
+
+}
+
+func ParseFlyteURL(flyteURL string) (core.NodeExecutionIdentifier, *int, ArtifactType, error) {
 	matches := MatchRegex(re, flyteURL)
 	proj := matches["project"]
 	domain := matches["domain"]
@@ -54,7 +140,7 @@ func ParseFlyteURL(flyteURL string) (core.NodeExecutionIdentifier, *int, Artifac
 		}
 		attemptPtr = &a
 	}
-	ioType, err := ArtifactTypeString(matches["artifactType"])
+	ioType, err := ArtifactTypeString(matches["IOType"])
 	if err != nil {
 		return core.NodeExecutionIdentifier{}, nil, ArtifactTypeUndefined, err
 	}

--- a/pkg/common/flyte_url_test.go
+++ b/pkg/common/flyte_url_test.go
@@ -201,12 +201,12 @@ func TestTryMatches(t *testing.T) {
 		assert.Nil(t, x)
 
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/o/o0")
-		assert.Equal(t, "o0", x["OutputName"])
+		assert.Equal(t, "o0", x["LiteralName"])
 
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/3/o/o0")
 		assert.Equal(t, "fs", x["project"])
 		assert.Equal(t, "dev", x["domain"])
-		assert.Equal(t, "o0", x["OutputName"])
+		assert.Equal(t, "o0", x["LiteralName"])
 		assert.Equal(t, "3", x["attempt"])
 		assert.Equal(t, "n0", x["node"])
 		assert.Equal(t, "abc", x["exec"])
@@ -214,7 +214,7 @@ func TestTryMatches(t *testing.T) {
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/3/i")
 		assert.Equal(t, "fs", x["project"])
 		assert.Equal(t, "dev", x["domain"])
-		assert.Equal(t, "", x["OutputName"])
+		assert.Equal(t, "", x["LiteralName"])
 		assert.Equal(t, "3", x["attempt"])
 		assert.Equal(t, "n0", x["node"])
 		assert.Equal(t, "abc", x["exec"])
@@ -222,7 +222,7 @@ func TestTryMatches(t *testing.T) {
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/i")
 		assert.Equal(t, "fs", x["project"])
 		assert.Equal(t, "dev", x["domain"])
-		assert.Equal(t, "", x["OutputName"])
+		assert.Equal(t, "", x["LiteralName"])
 		assert.Equal(t, "", x["attempt"])
 		assert.Equal(t, "n0", x["node"])
 		assert.Equal(t, "abc", x["exec"])
@@ -240,7 +240,7 @@ func TestParseFlyteURLToExecution(t *testing.T) {
 		assert.Equal(t, "abc", x.PartialTaskExecID.NodeExecutionId.ExecutionId.Name)
 		assert.Equal(t, "n0", x.PartialTaskExecID.NodeExecutionId.NodeId)
 		assert.Equal(t, uint32(3), x.PartialTaskExecID.GetRetryAttempt())
-		assert.Equal(t, "o0", x.OutputName)
+		assert.Equal(t, "o0", x.LiteralName)
 	})
 
 	t.Run("node and attempt url no output", func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestParseFlyteURLToExecution(t *testing.T) {
 		assert.Equal(t, "abc", x.PartialTaskExecID.NodeExecutionId.ExecutionId.Name)
 		assert.Equal(t, "n0", x.PartialTaskExecID.NodeExecutionId.NodeId)
 		assert.Equal(t, uint32(3), x.PartialTaskExecID.GetRetryAttempt())
-		assert.Equal(t, "", x.OutputName)
+		assert.Equal(t, "", x.LiteralName)
 	})
 
 	t.Run("node url with output", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestParseFlyteURLToExecution(t *testing.T) {
 		assert.Equal(t, "dev", x.NodeExecID.ExecutionId.Domain)
 		assert.Equal(t, "abc", x.NodeExecID.ExecutionId.Name)
 		assert.Equal(t, "n0", x.NodeExecID.NodeId)
-		assert.Equal(t, "o0", x.OutputName)
+		assert.Equal(t, "o0", x.LiteralName)
 	})
 
 	t.Run("node url no output", func(t *testing.T) {
@@ -277,6 +277,6 @@ func TestParseFlyteURLToExecution(t *testing.T) {
 		assert.Equal(t, "dev", x.NodeExecID.ExecutionId.Domain)
 		assert.Equal(t, "abc", x.NodeExecID.ExecutionId.Name)
 		assert.Equal(t, "n0", x.NodeExecID.NodeId)
-		assert.Equal(t, "", x.OutputName)
+		assert.Equal(t, "", x.LiteralName)
 	})
 }

--- a/pkg/common/flyte_url_test.go
+++ b/pkg/common/flyte_url_test.go
@@ -1,87 +1,11 @@
 package common
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestParseFlyteUrl(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		ne, attempt, kind, err := ParseFlyteURL("flyte://v1/fs/dev/abc/n0/0/o")
-		assert.NoError(t, err)
-		assert.Equal(t, 0, *attempt)
-		assert.Equal(t, ArtifactTypeO, kind)
-		assert.True(t, proto.Equal(&core.NodeExecutionIdentifier{
-			NodeId: "n0",
-			ExecutionId: &core.WorkflowExecutionIdentifier{
-				Project: "fs",
-				Domain:  "dev",
-				Name:    "abc",
-			},
-		}, &ne))
-		ne, attempt, kind, err = ParseFlyteURL("flyte://v1/fs/dev/abc/n0/i")
-		assert.NoError(t, err)
-		assert.Nil(t, attempt)
-		assert.Equal(t, ArtifactTypeI, kind)
-		assert.True(t, proto.Equal(&core.NodeExecutionIdentifier{
-			NodeId: "n0",
-			ExecutionId: &core.WorkflowExecutionIdentifier{
-				Project: "fs",
-				Domain:  "dev",
-				Name:    "abc",
-			},
-		}, &ne))
-
-		ne, attempt, kind, err = ParseFlyteURL("flyte://v1/fs/dev/abc/n0/d")
-		assert.NoError(t, err)
-		assert.Nil(t, attempt)
-		assert.Equal(t, ArtifactTypeD, kind)
-		assert.True(t, proto.Equal(&core.NodeExecutionIdentifier{
-			NodeId: "n0",
-			ExecutionId: &core.WorkflowExecutionIdentifier{
-				Project: "fs",
-				Domain:  "dev",
-				Name:    "abc",
-			},
-		}, &ne))
-
-		ne, attempt, kind, err = ParseFlyteURL("flyte://v1/fs/dev/abc/n0-dn0-9-n0-n0/d")
-		assert.NoError(t, err)
-		assert.Nil(t, attempt)
-		assert.Equal(t, ArtifactTypeD, kind)
-		assert.True(t, proto.Equal(&core.NodeExecutionIdentifier{
-			NodeId: "n0-dn0-9-n0-n0",
-			ExecutionId: &core.WorkflowExecutionIdentifier{
-				Project: "fs",
-				Domain:  "dev",
-				Name:    "abc",
-			},
-		}, &ne))
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		// more than one character
-		_, attempt, kind, err := ParseFlyteURL("flyte://v1/fs/dev/abc/n0/0/od")
-		assert.Error(t, err)
-		assert.Nil(t, attempt)
-		assert.Equal(t, ArtifactTypeUndefined, kind)
-
-		_, attempt, kind, err = ParseFlyteURL("flyte://v1/fs/dev/abc/n0/input")
-		assert.Error(t, err)
-		assert.Nil(t, attempt)
-		assert.Equal(t, ArtifactTypeUndefined, kind)
-
-		// non integer for attempt
-		_, attempt, kind, err = ParseFlyteURL("flyte://v1/fs/dev/ab/n0/a/i")
-		assert.Error(t, err)
-		assert.Nil(t, attempt)
-		assert.Equal(t, ArtifactTypeUndefined, kind)
-	})
-}
 
 func TestFlyteURLsFromNodeExecutionID(t *testing.T) {
 	t.Run("with deck", func(t *testing.T) {
@@ -177,21 +101,59 @@ func TestMatchRegexDirectly(t *testing.T) {
 func TestDirectRegexMatching(t *testing.T) {
 	t.Run("regex with specific output no attempt", func(t *testing.T) {
 		matches := MatchRegex(reSpecificOutput, "flyte://v1/fs/dev/abc/n0/o/o0")
-		fmt.Println(matches)
-
+		assert.Equal(t, map[string]string{
+			"project":     "fs",
+			"domain":      "dev",
+			"exec":        "abc",
+			"node":        "n0",
+			"attempt":     "",
+			"literalName": "o0",
+			"ioType":      "o",
+		}, matches)
 	})
 
 	t.Run("regex with specific output no attempt", func(t *testing.T) {
 		matches := MatchRegex(reSpecificOutput, "flyte://v1/fs/dev/abc/n0-dn0-9-n0-n0/o/o0")
-		fmt.Println(matches)
+		assert.Equal(t, map[string]string{
+			"project":     "fs",
+			"domain":      "dev",
+			"exec":        "abc",
+			"node":        "n0-dn0-9-n0-n0",
+			"attempt":     "",
+			"literalName": "o0",
+			"ioType":      "o",
+		}, matches)
 	})
 
 	t.Run("regex with specific output with attempt", func(t *testing.T) {
 		matches := MatchRegex(reSpecificOutput, "flyte://v1/fs/dev/abc/n0-dn0-9-n0-n0/5/o/o0")
-		fmt.Println(matches)
+		assert.Equal(t, map[string]string{
+			"project":     "fs",
+			"domain":      "dev",
+			"exec":        "abc",
+			"node":        "n0-dn0-9-n0-n0",
+			"attempt":     "5",
+			"literalName": "o0",
+			"ioType":      "o",
+		}, matches)
 
 		normal := MatchRegex(re, "flyte://v1/fs/dev/abc/n0-dn0-9-n0-n0/5/o/o0")
 		assert.Equal(t, 0, len(normal))
+	})
+
+	t.Run("regex with specific output no attempt", func(t *testing.T) {
+		specific := MatchRegex(reSpecificOutput, "flyte://v1/fs/dev/abc/n0-dn0-9-n0-n0/5/o")
+		assert.Equal(t, 0, len(specific))
+
+		matches := MatchRegex(re, "flyte://v1/fs/dev/abc/n0-dn0-9-n0-n0/5/o")
+		assert.Equal(t, map[string]string{
+			"project": "fs",
+			"domain":  "dev",
+			"exec":    "abc",
+			"node":    "n0-dn0-9-n0-n0",
+			"attempt": "5",
+			"ioType":  "o",
+		}, matches)
 	})
 }
 
@@ -201,12 +163,12 @@ func TestTryMatches(t *testing.T) {
 		assert.Nil(t, x)
 
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/o/o0")
-		assert.Equal(t, "o0", x["LiteralName"])
+		assert.Equal(t, "o0", x["literalName"])
 
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/3/o/o0")
 		assert.Equal(t, "fs", x["project"])
 		assert.Equal(t, "dev", x["domain"])
-		assert.Equal(t, "o0", x["LiteralName"])
+		assert.Equal(t, "o0", x["literalName"])
 		assert.Equal(t, "3", x["attempt"])
 		assert.Equal(t, "n0", x["node"])
 		assert.Equal(t, "abc", x["exec"])
@@ -214,7 +176,7 @@ func TestTryMatches(t *testing.T) {
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/3/i")
 		assert.Equal(t, "fs", x["project"])
 		assert.Equal(t, "dev", x["domain"])
-		assert.Equal(t, "", x["LiteralName"])
+		assert.Equal(t, "", x["literalName"])
 		assert.Equal(t, "3", x["attempt"])
 		assert.Equal(t, "n0", x["node"])
 		assert.Equal(t, "abc", x["exec"])
@@ -222,7 +184,7 @@ func TestTryMatches(t *testing.T) {
 		x = tryMatches("flyte://v1/fs/dev/abc/n0/i")
 		assert.Equal(t, "fs", x["project"])
 		assert.Equal(t, "dev", x["domain"])
-		assert.Equal(t, "", x["LiteralName"])
+		assert.Equal(t, "", x["literalName"])
 		assert.Equal(t, "", x["attempt"])
 		assert.Equal(t, "n0", x["node"])
 		assert.Equal(t, "abc", x["exec"])
@@ -278,5 +240,44 @@ func TestParseFlyteURLToExecution(t *testing.T) {
 		assert.Equal(t, "abc", x.NodeExecID.ExecutionId.Name)
 		assert.Equal(t, "n0", x.NodeExecID.NodeId)
 		assert.Equal(t, "", x.LiteralName)
+	})
+
+	t.Run("node url all inputs", func(t *testing.T) {
+		x, err := ParseFlyteURLToExecution("flyte://v1/fs/dev/abc/n0/i")
+		assert.NoError(t, err)
+		assert.NotNil(t, x.NodeExecID)
+		assert.Nil(t, x.PartialTaskExecID)
+		assert.Equal(t, "fs", x.NodeExecID.ExecutionId.Project)
+		assert.Equal(t, "dev", x.NodeExecID.ExecutionId.Domain)
+		assert.Equal(t, "abc", x.NodeExecID.ExecutionId.Name)
+		assert.Equal(t, "n0", x.NodeExecID.NodeId)
+		assert.Equal(t, "", x.LiteralName)
+		assert.Equal(t, ArtifactTypeI, x.IOType)
+	})
+
+	t.Run("node url all inputs", func(t *testing.T) {
+		x, err := ParseFlyteURLToExecution("flyte://v1/fs/dev/abc/n0/d")
+		assert.NoError(t, err)
+		assert.NotNil(t, x.NodeExecID)
+		assert.Nil(t, x.PartialTaskExecID)
+		assert.Equal(t, "fs", x.NodeExecID.ExecutionId.Project)
+		assert.Equal(t, "dev", x.NodeExecID.ExecutionId.Domain)
+		assert.Equal(t, "abc", x.NodeExecID.ExecutionId.Name)
+		assert.Equal(t, "n0", x.NodeExecID.NodeId)
+		assert.Equal(t, "", x.LiteralName)
+		assert.Equal(t, ArtifactTypeD, x.IOType)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		// more than one character
+		_, err := ParseFlyteURLToExecution("flyte://v1/fs/dev/abc/n0/0/od")
+		assert.Error(t, err)
+
+		_, err = ParseFlyteURLToExecution("flyte://v1/fs/dev/abc/n0/input")
+		assert.Error(t, err)
+
+		// non integer for attempt
+		_, err = ParseFlyteURLToExecution("flyte://v1/fs/dev/ab/n0/a/i")
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
# TL;DR
This adds the ability to return an individual input or output in the flyte url, e.g.
```
flyte://v1/flytesnacks/development/ad5cb55f675g2s78swgp/end-node/i/o0
```

There's currently no mechanism by which these URLs can be returned to the frontend however.  This can be worked on separately.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Refactored out the parsing logic to return a union instead.  go doesn't have unions so returning a struct.
* Split out the GetData function into one for node level and one for task execution level.
* Added a second regex object to try to match against.

## Tracking Issue
NA
