### PR TITLE
Update startedAt timestamp only if not set

### DIFF
--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -5,25 +5,22 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
-	"github.com/flyteorg/flytestdlib/storage"
-
-	"google.golang.org/protobuf/encoding/protojson"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	_struct "github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	"github.com/flyteorg/flyteadmin/pkg/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
+	"github.com/flyteorg/flyteadmin/pkg/runtime/interfaces"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flytestdlib/logger"
-
-	"google.golang.org/grpc/codes"
+	"github.com/flyteorg/flytestdlib/storage"
 )
 
 var empty _struct.Struct

--- a/pkg/repositories/transformers/task_execution.go
+++ b/pkg/repositories/transformers/task_execution.go
@@ -11,6 +11,10 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	_struct "github.com/golang/protobuf/ptypes/struct"
+
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	"github.com/flyteorg/flyteadmin/pkg/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
@@ -18,9 +22,6 @@ import (
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flytestdlib/logger"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	_struct "github.com/golang/protobuf/ptypes/struct"
 
 	"google.golang.org/grpc/codes"
 )
@@ -40,8 +41,13 @@ func addTaskStartedState(request *admin.TaskExecutionEventRequest, taskExecution
 	if err != nil {
 		return errors.NewFlyteAdminErrorf(codes.Internal, "failed to unmarshal occurredAt with error: %v", err)
 	}
-	taskExecutionModel.StartedAt = &occurredAt
-	closure.StartedAt = request.Event.OccurredAt
+	//Updated the startedAt timestamp only if its not set.
+	// The task start event should already be updating this through addTaskStartedState
+	// This check makes sure any out of order
+	if taskExecutionModel.StartedAt == nil {
+		taskExecutionModel.StartedAt = &occurredAt
+		closure.StartedAt = request.Event.OccurredAt
+	}
 	return nil
 }
 


### PR DESCRIPTION
# TL;DR
Updation of the startedAt timestamp for same taskExecution happens in case of map tasks.
So when propeller send the TaskExecutionEvents for each mappedTask, admin records the event and if it finds it to be Running, then calls the addTaskStartedState function which update the startedAt timestamp.

This is fine to do in case of regular task but incase of mapped task, each mappedTask status causes an update to startedAt which is incorrect.
This PR fixes it by guarding it with if the values is not set

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/3702

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
