### PR TITLE
Alter ID sequence to bigint

### DIFF
--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -1083,16 +1083,39 @@ var NoopMigrations = []*gormigrate.Migration{
 			return nil
 		},
 	},
+
+	{
+		ID: "2023-06-19-id-sequence-to-bigint",
+		Migrate: func(tx *gorm.DB) error {
+			db, err := tx.DB()
+			if err != nil {
+				return err
+			}
+			return alterIDSequenceType(db)
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	},
 }
 
 var Migrations = append(LegacyMigrations, NoopMigrations...)
 
 func alterTableColumnType(db *sql.DB, columnName, columnType string) error {
-
 	var err error
 	for _, table := range tables {
 		if _, err = db.Exec(fmt.Sprintf(`ALTER TABLE IF EXISTS %s ALTER COLUMN "%s" TYPE %s`, table, columnName,
 			columnType)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func alterIDSequenceType(db *sql.DB) error {
+	var err error
+	for _, table := range tables {
+		if _, err = db.Exec(fmt.Sprintf(`ALTER SEQUENCE IF EXISTS %s_id_seq AS bigint NO MAXVALUE`, table)); err != nil {
 			return err
 		}
 	}

--- a/pkg/repositories/config/migrations_test.go
+++ b/pkg/repositories/config/migrations_test.go
@@ -25,6 +25,20 @@ func TestAlterTableColumnType(t *testing.T) {
 	assert.True(t, query.Triggered)
 }
 
+func TestAlterIDSequenceType(t *testing.T) {
+	gormDb := GetDbForTest(t)
+	db, err := gormDb.DB()
+	GlobalMock := mocket.Catcher.Reset()
+	GlobalMock.Logging = true
+	query := GlobalMock.NewMock()
+	query.WithQuery(
+		`ALTER SEQUENCE IF EXISTS execution_events_id_seq AS bigint NO MAXVALUE`)
+	assert.NoError(t, err)
+	tables = []string{"execution_events"}
+	_ = alterIDSequenceType(db)
+	assert.True(t, query.Triggered)
+}
+
 func GetDbForTest(t *testing.T) *gorm.DB {
 	mocket.Catcher.Register()
 	db, err := gorm.Open(postgres.New(postgres.Config{DriverName: mocket.DriverName}))


### PR DESCRIPTION
# TL;DR
Alter ID sequence to bigint.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

I tested the sql on one of our sequences and it worked as expected.

## Complete description
As described by https://github.com/flyteorg/flyte/issues/3777, some of the ID sequences are not bigint due to historical reason. It makes sense to use bigint because integer is easy to run out of.

Note that this PR does not try to change `cycle` in order to keep backward compatibility, and also `bigint` will practically make that unnecessary.

For reference https://www.postgresql.org/docs/current/sql-altersequence.html

## Tracking Issue
Fixes https://github.com/flyteorg/flyte/issues/3777

## Follow-up issue
_NA_