### PR TITLE
Introduce pre redirect hook plugin during auth callback

### DIFF
--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -211,7 +211,6 @@ func GetCallbackHandler(ctx context.Context, authCtx interfaces.AuthenticationCo
 			logger.Info(ctx, "Successfully called the preRedirect hook")
 		}
 		redirectURL := getAuthFlowEndRedirect(ctx, authCtx, request)
-		logger.Infof(ctx, "Going to perform the redirect with redirectURl %v", redirectURL)
 		http.Redirect(writer, request, redirectURL, http.StatusTemporaryRedirect)
 	}
 }

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -182,10 +182,12 @@ func GetCallbackHandler(ctx context.Context, authCtx interfaces.AuthenticationCo
 
 		preRedirectHook := plugins.Get[PreRedirectHookFunc](pluginRegistry, plugins.PluginIDPreRedirectHook)
 		if preRedirectHook != nil {
+			logger.Infof(ctx, "preRedirect hook is set")
 			if err := preRedirectHook(ctx); err != nil {
 				logger.Errorf(ctx, "failed the preRedirect hook due to %v", err)
 				writer.WriteHeader(http.StatusInternalServerError)
 			}
+			logger.Infof(ctx, "Successfully called the preRedirect hook")
 		}
 		redirectURL := getAuthFlowEndRedirect(ctx, authCtx, request)
 		http.Redirect(writer, request, redirectURL, http.StatusTemporaryRedirect)

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -189,12 +189,27 @@ func GetCallbackHandler(ctx context.Context, authCtx interfaces.AuthenticationCo
 		preRedirectHook := plugins.Get[PreRedirectHookFunc](pluginRegistry, plugins.PluginIDPreRedirectHook)
 		if preRedirectHook != nil {
 			logger.Infof(ctx, "preRedirect hook is set")
-			if err := preRedirectHook(ctx, authCtx, request, writer); err != nil {
-				logger.Errorf(ctx, "failed the preRedirect hook due to %v", err)
+			redirectHookCtx := ctx
+			if idTokenRaw, converted := token.Extra(idTokenExtra).(string); converted {
+				identityContext, err := IdentityContextFromIDTokenToken(redirectHookCtx, idTokenRaw, authCtx.Options().UserAuth.OpenID.ClientID,
+					authCtx.OidcProvider(), userInfo)
+				if err != nil {
+					logger.Errorf(redirectHookCtx, "failed to get identity context from the IDToken due to %v", err)
+					writer.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				redirectHookCtx = identityContext.WithContext(ctx)
+			} else {
+				logger.Errorf(redirectHookCtx, "failed to get IDToken from the exchanged token with the auth server")
+				writer.WriteHeader(http.StatusInternalServerError)
+			}
+
+			if err := preRedirectHook(redirectHookCtx, authCtx, request, writer); err != nil {
+				logger.Errorf(redirectHookCtx, "failed the preRedirect hook due to %v", err)
 				writer.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			logger.Infof(ctx, "Successfully called the preRedirect hook")
+			logger.Infof(redirectHookCtx, "Successfully called the preRedirect hook")
 		}
 		redirectURL := getAuthFlowEndRedirect(ctx, authCtx, request)
 		logger.Infof(ctx, "Going to perform the redirect with redirectURl %v", redirectURL)

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -179,8 +179,7 @@ func TestGetCallbackHandler(t *testing.T) {
 	t.Run("successful callback with redirect and successful preredirect hook call", func(t *testing.T) {
 		mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
 		r := plugins.NewRegistry()
-		var redirectFunc PreRedirectHookFunc
-		redirectFunc = func(redirectContext context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, responseWriter http.ResponseWriter) *PreRedirectHookError {
+		var redirectFunc PreRedirectHookFunc = func(redirectContext context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, responseWriter http.ResponseWriter) *PreRedirectHookError {
 			return nil
 		}
 
@@ -208,8 +207,7 @@ func TestGetCallbackHandler(t *testing.T) {
 	t.Run("successful callback with pre-redirecthook failure", func(t *testing.T) {
 		mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
 		r := plugins.NewRegistry()
-		var redirectFunc PreRedirectHookFunc
-		redirectFunc = func(redirectContext context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, responseWriter http.ResponseWriter) *PreRedirectHookError {
+		var redirectFunc PreRedirectHookFunc = func(redirectContext context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, responseWriter http.ResponseWriter) *PreRedirectHookError {
 			return &PreRedirectHookError{
 				Code:    http.StatusPreconditionFailed,
 				Message: "precondition error",

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -10,18 +10,19 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/flyteorg/flyteadmin/auth/config"
-	"github.com/flyteorg/flyteadmin/auth/interfaces/mocks"
-	"github.com/flyteorg/flyteadmin/pkg/common"
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
-	stdConfig "github.com/flyteorg/flytestdlib/config"
-
 	"github.com/coreos/go-oidc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/flyteorg/flyteadmin/auth/config"
+	"github.com/flyteorg/flyteadmin/auth/interfaces"
+	"github.com/flyteorg/flyteadmin/auth/interfaces/mocks"
+	"github.com/flyteorg/flyteadmin/pkg/common"
+	"github.com/flyteorg/flyteadmin/plugins"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
+	stdConfig "github.com/flyteorg/flytestdlib/config"
 )
 
 const (
@@ -81,7 +82,8 @@ func TestGetCallbackHandlerWithErrorOnToken(t *testing.T) {
 	defer localServer.Close()
 	http.DefaultClient = localServer.Client()
 	mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
-	callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx)
+	r := plugins.NewRegistry()
+	callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, r)
 	request := httptest.NewRequest("GET", localServer.URL+"/callback", nil)
 	addCsrfCookie(request)
 	addStateString(request)
@@ -102,7 +104,8 @@ func TestGetCallbackHandlerWithUnAuthorized(t *testing.T) {
 	defer localServer.Close()
 	http.DefaultClient = localServer.Client()
 	mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
-	callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx)
+	r := plugins.NewRegistry()
+	callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, r)
 	request := httptest.NewRequest("GET", localServer.URL+"/callback", nil)
 	writer := httptest.NewRecorder()
 	callbackHandlerFunc(writer, request)
@@ -153,7 +156,8 @@ func TestGetCallbackHandler(t *testing.T) {
 
 	t.Run("forbidden request when accessing user info", func(t *testing.T) {
 		mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
-		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, nil)
+		r := plugins.NewRegistry()
+		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, r)
 		request := httptest.NewRequest("GET", localServer.URL+"/callback", nil)
 		addCsrfCookie(request)
 		addStateString(request)
@@ -172,9 +176,16 @@ func TestGetCallbackHandler(t *testing.T) {
 		assert.Equal(t, "403 Forbidden", writer.Result().Status)
 	})
 
-	t.Run("successful callback and redirect", func(t *testing.T) {
+	t.Run("successful callback with redirect and successful preredirect hook call", func(t *testing.T) {
 		mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
-		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx)
+		r := plugins.NewRegistry()
+		var redirectFunc PreRedirectHookFunc
+		redirectFunc = func(redirectContext context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, responseWriter http.ResponseWriter) *PreRedirectHookError {
+			return nil
+		}
+
+		r.RegisterDefault(plugins.PluginIDPreRedirectHook, redirectFunc)
+		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, r)
 		request := httptest.NewRequest("GET", localServer.URL+"/callback", nil)
 		addCsrfCookie(request)
 		addStateString(request)
@@ -192,6 +203,38 @@ func TestGetCallbackHandler(t *testing.T) {
 		mockAuthCtx.OnOidcProviderMatch().Return(oidcProvider)
 		callbackHandlerFunc(writer, request)
 		assert.Equal(t, "307 Temporary Redirect", writer.Result().Status)
+	})
+
+	t.Run("successful callback with pre-redirecthook failure", func(t *testing.T) {
+		mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
+		r := plugins.NewRegistry()
+		var redirectFunc PreRedirectHookFunc
+		redirectFunc = func(redirectContext context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, responseWriter http.ResponseWriter) *PreRedirectHookError {
+			return &PreRedirectHookError{
+				Code:    http.StatusPreconditionFailed,
+				Message: "precondition error",
+			}
+		}
+
+		r.RegisterDefault(plugins.PluginIDPreRedirectHook, redirectFunc)
+		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, r)
+		request := httptest.NewRequest("GET", localServer.URL+"/callback", nil)
+		addCsrfCookie(request)
+		addStateString(request)
+		writer := httptest.NewRecorder()
+		openIDConfigJSON = fmt.Sprintf(`{
+				"userinfo_endpoint": "%v/userinfo",
+				"issuer": "%v",
+				"authorization_endpoint": "%v/auth",
+				"token_endpoint": "%v/token",
+				"jwks_uri": "%v/keys",
+				"id_token_signing_alg_values_supported": ["RS256"]
+			}`, issuer, issuer, issuer, issuer, issuer)
+		oidcProvider, err := oidc.NewProvider(ctx, issuer)
+		assert.Nil(t, err)
+		mockAuthCtx.OnOidcProviderMatch().Return(oidcProvider)
+		callbackHandlerFunc(writer, request)
+		assert.Equal(t, "412 Precondition Failed", writer.Result().Status)
 	})
 }
 

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -153,7 +153,7 @@ func TestGetCallbackHandler(t *testing.T) {
 
 	t.Run("forbidden request when accessing user info", func(t *testing.T) {
 		mockAuthCtx := setupMockedAuthContextAtEndpoint(localServer.URL)
-		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx)
+		callbackHandlerFunc := GetCallbackHandler(ctx, mockAuthCtx, nil)
 		request := httptest.NewRequest("GET", localServer.URL+"/callback", nil)
 		addCsrfCookie(request)
 		addStateString(request)

--- a/plugins/registry.go
+++ b/plugins/registry.go
@@ -12,6 +12,7 @@ const (
 	PluginIDWorkflowExecutor       PluginID = "WorkflowExecutor"
 	PluginIDDataProxy              PluginID = "DataProxy"
 	PluginIDUnaryServiceMiddleware PluginID = "UnaryServiceMiddleware"
+	PluginIDPreRedirectHook        PluginID = "PreRedirectHook"
 )
 
 type AtomicRegistry struct {

--- a/plugins/registry_test.go
+++ b/plugins/registry_test.go
@@ -29,8 +29,7 @@ func TestRedirectHook(t *testing.T) {
 	ar := NewAtomicRegistry(nil)
 	r := NewRegistry()
 
-	var redirectHookfn PreRedirectHookFunc
-	redirectHookfn = func(ctx context.Context) error {
+	var redirectHookfn PreRedirectHookFunc = func(ctx context.Context) error {
 		return fmt.Errorf("redirect hook error")
 	}
 	err := r.Register(PluginIDPreRedirectHook, redirectHookfn)

--- a/plugins/registry_test.go
+++ b/plugins/registry_test.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +21,25 @@ func TestNewAtomicRegistry(t *testing.T) {
 	ar.Store(r)
 	r = ar.Load()
 	assert.Equal(t, 5, r.Get(PluginIDDataProxy))
+}
+
+type PreRedirectHookFunc func(ctx context.Context) error
+
+func TestRedirectHook(t *testing.T) {
+	ar := NewAtomicRegistry(nil)
+	r := NewRegistry()
+
+	var redirectHookfn PreRedirectHookFunc
+	redirectHookfn = func(ctx context.Context) error {
+		return fmt.Errorf("redirect hook error")
+	}
+	err := r.Register(PluginIDPreRedirectHook, redirectHookfn)
+	assert.NoError(t, err)
+	ar.Store(r)
+	r = ar.Load()
+	fn := Get[PreRedirectHookFunc](r, PluginIDPreRedirectHook)
+	err = fn(context.Background())
+	assert.Equal(t, fmt.Errorf("redirect hook error"), err)
 }
 
 func TestRegistry_RegisterDefault(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Introduces a preRedirectHook plugin handler to allow custom code to be able to be plugged in before the successful auth call back redirect happens


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

```
type PreRedirectHookFunc func(ctx context.Context, authCtx interfaces.AuthenticationContext, request *http.Request, w http.ResponseWriter) *PreRedirectHookError
```

PreRedirectHookFunc Interface is used for running custom code before the redirect happens during a successful auth flow.

The API allows you to access the authenticationContext, request and response 

This might be useful in cases where the auth flow allows the user to login since the IDP has been configured
for eg: to allow all users from a particular domain to login but you want to restrict access to only a particular set of user ids. eg : users@domain.com are allowed to login but user user1@domain.com, user2@domain.com should only be allowed

The current Plugin hook will allow you to add such a custom code.

PreRedirectHookError is the error interface which allows the user to set correct http status code and Message to be set in case the function returns an error without which the current usage in GetCallbackHandler will set this to InternalServerError


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3940

## Follow-up issue
_NA_
