### PR TITLE
Fix SQL injection in List filters

### DIFF
--- a/pkg/repositories/gormimpl/common.go
+++ b/pkg/repositories/gormimpl/common.go
@@ -2,14 +2,17 @@ package gormimpl
 
 import (
 	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	adminErrors "github.com/flyteorg/flyteadmin/pkg/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
-
-	"google.golang.org/grpc/codes"
-	"gorm.io/gorm"
 )
 
 const Project = "project"
@@ -114,4 +117,12 @@ func applyScopedFilters(tx *gorm.DB, inlineFilters []common.InlineFilter, mapFil
 		tx = tx.Where(mapFilter.GetFilter())
 	}
 	return tx, nil
+}
+
+func modelColumns(v any) sets.String {
+	s, err := schema.Parse(v, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		panic(err)
+	}
+	return sets.NewString(s.DBNames...)
 }

--- a/pkg/repositories/gormimpl/execution_repo.go
+++ b/pkg/repositories/gormimpl/execution_repo.go
@@ -5,14 +5,20 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flytestdlib/promutils"
+
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	adminErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flytestdlib/promutils"
 
 	"gorm.io/gorm"
+)
+
+var (
+	ExecutionColumns = modelColumns(models.Execution{})
+	AdminTagColumns  = modelColumns(models.AdminTag{})
 )
 
 // Implementation of ExecutionInterface.

--- a/pkg/repositories/gormimpl/launch_plan_repo.go
+++ b/pkg/repositories/gormimpl/launch_plan_repo.go
@@ -8,12 +8,15 @@ import (
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/promutils"
 
+	"github.com/flyteorg/flytestdlib/logger"
+	"gorm.io/gorm"
+
 	adminErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"github.com/flyteorg/flytestdlib/logger"
-	"gorm.io/gorm"
 )
+
+var LaunchPlanColumns = modelColumns(models.LaunchPlan{})
 
 const launchPlanTableName = "launch_plans"
 

--- a/pkg/repositories/gormimpl/named_entity_repo.go
+++ b/pkg/repositories/gormimpl/named_entity_repo.go
@@ -7,13 +7,19 @@ import (
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"google.golang.org/grpc/codes"
 
+	"github.com/flyteorg/flytestdlib/promutils"
+	"gorm.io/gorm"
+
 	"github.com/flyteorg/flyteadmin/pkg/common"
 	adminErrors "github.com/flyteorg/flyteadmin/pkg/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"github.com/flyteorg/flytestdlib/promutils"
-	"gorm.io/gorm"
+)
+
+var (
+	NamedEntityColumns         = modelColumns(models.NamedEntity{})
+	NamedEntityMetadataColumns = modelColumns(models.NamedEntityMetadata{})
 )
 
 const innerJoinTableAlias = "entities"

--- a/pkg/repositories/gormimpl/node_execution_event_repo.go
+++ b/pkg/repositories/gormimpl/node_execution_event_repo.go
@@ -3,12 +3,15 @@ package gormimpl
 import (
 	"context"
 
+	"github.com/flyteorg/flytestdlib/promutils"
+	"gorm.io/gorm"
+
 	"github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"github.com/flyteorg/flytestdlib/promutils"
-	"gorm.io/gorm"
 )
+
+var NodeExecutionEventColumns = modelColumns(models.NodeExecutionEvent{})
 
 type NodeExecutionEventRepo struct {
 	db               *gorm.DB

--- a/pkg/repositories/gormimpl/node_execution_repo.go
+++ b/pkg/repositories/gormimpl/node_execution_repo.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flytestdlib/promutils"
+	"gorm.io/gorm"
 
 	adminErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"gorm.io/gorm"
 )
+
+var NodeExecutionColumns = modelColumns(models.NodeExecution{})
 
 // Implementation of NodeExecutionInterface.
 type NodeExecutionRepo struct {

--- a/pkg/repositories/gormimpl/project_repo.go
+++ b/pkg/repositories/gormimpl/project_repo.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"errors"
 
-	flyteAdminErrors "github.com/flyteorg/flyteadmin/pkg/errors"
-	"google.golang.org/grpc/codes"
-
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flytestdlib/promutils"
-
+	"google.golang.org/grpc/codes"
 	"gorm.io/gorm"
 
+	flyteAdminErrors "github.com/flyteorg/flyteadmin/pkg/errors"
 	flyteAdminDbErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
 )
+
+var ProjectColumns = modelColumns(models.Project{})
 
 type ProjectRepo struct {
 	db               *gorm.DB

--- a/pkg/repositories/gormimpl/signal_repo.go
+++ b/pkg/repositories/gormimpl/signal_repo.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"errors"
 
+	"github.com/flyteorg/flytestdlib/promutils"
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
+
 	adminerrors "github.com/flyteorg/flyteadmin/pkg/errors"
 	flyteAdminDbErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-
-	"github.com/flyteorg/flytestdlib/promutils"
-
-	"google.golang.org/grpc/codes"
-
-	"gorm.io/gorm"
 )
+
+var SignalColumns = modelColumns(models.Signal{})
 
 // SignalRepo is an implementation of SignalRepoInterface.
 type SignalRepo struct {

--- a/pkg/repositories/gormimpl/task_execution_repo.go
+++ b/pkg/repositories/gormimpl/task_execution_repo.go
@@ -5,14 +5,15 @@ import (
 	"errors"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flytestdlib/promutils"
+	"gorm.io/gorm"
 
 	flyteAdminDbErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"gorm.io/gorm"
 )
+
+var TaskExecutionColumns = modelColumns(models.TaskExecution{})
 
 // Implementation of TaskExecutionInterface.
 type TaskExecutionRepo struct {

--- a/pkg/repositories/gormimpl/task_repo.go
+++ b/pkg/repositories/gormimpl/task_repo.go
@@ -5,14 +5,15 @@ import (
 	"errors"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/flyteorg/flytestdlib/promutils"
+	"gorm.io/gorm"
 
 	flyteAdminDbErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
 	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
-	"gorm.io/gorm"
 )
+
+var TaskColumns = modelColumns(models.Task{})
 
 // Implementation of TaskRepoInterface.
 type TaskRepo struct {

--- a/pkg/repositories/gormimpl/workflow_repo.go
+++ b/pkg/repositories/gormimpl/workflow_repo.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 
-	flyteAdminDbErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
-	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
-	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"gorm.io/gorm"
+
+	flyteAdminDbErrors "github.com/flyteorg/flyteadmin/pkg/repositories/errors"
+	"github.com/flyteorg/flyteadmin/pkg/repositories/interfaces"
+	"github.com/flyteorg/flyteadmin/pkg/repositories/models"
 )
+
+var WorkflowColumns = modelColumns(models.Workflow{})
 
 // Implementation of WorkflowRepoInterface.
 type WorkflowRepo struct {


### PR DESCRIPTION
# TL;DR
Validate filters in List API endpoints so that they only contain supported columns and columns of joined tables. 
SQL injection of sort keys is done in separate [PR](https://github.com/flyteorg/flyteadmin/pull/606) 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
